### PR TITLE
Update password label

### DIFF
--- a/stubs/resources/views/auth/login.blade.php
+++ b/stubs/resources/views/auth/login.blade.php
@@ -22,7 +22,7 @@
 
             <!-- Password -->
             <div class="mt-4">
-                <x-label for="email" :value="__('Password')" />
+                <x-label for="password" :value="__('Password')" />
 
                 <x-input id="password" class="block mt-1 w-full"
                                 type="password"


### PR DESCRIPTION
Minor, but the email label is duplicated. This updates the label for the password input correctly.