### PR TITLE
Makes breeze a --dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ laravel new my-app
 
 cd my-app
 
-composer require laravel/breeze
+composer require laravel/breeze --dev
 
 php artisan breeze:install
 ```


### PR DESCRIPTION
This pull request makes Breeze a `--dev` dependency, so people don't end up with this dependency in production.