### PR TITLE
Restoring old input values after a failed validation

### DIFF
--- a/stubs/App/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/App/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -41,6 +41,7 @@ class PasswordResetLinkController extends Controller
 
         return $status == Password::RESET_LINK_SENT
                     ? back()->with('status', __($status))
-                    : back()->withErrors(['email' => __($status)]);
+                    : back()->withInput($request->only('email'))
+                            ->withErrors(['email' => __($status)]);
     }
 }

--- a/stubs/App/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/App/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -29,7 +29,7 @@ class PasswordResetLinkController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'email' => 'required|email'
+            'email' => 'required|email',
         ]);
 
         // We will send the password reset link to this user. Once we have attempted

--- a/stubs/resources/views/auth/forgot-password.blade.php
+++ b/stubs/resources/views/auth/forgot-password.blade.php
@@ -23,7 +23,7 @@
             <div>
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" required autofocus />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required autofocus />
             </div>
 
             <div class="flex items-center justify-end mt-4">

--- a/stubs/resources/views/auth/login.blade.php
+++ b/stubs/resources/views/auth/login.blade.php
@@ -19,7 +19,7 @@
             <div>
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" required autofocus />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required autofocus />
             </div>
 
             <!-- Password -->

--- a/stubs/resources/views/auth/register.blade.php
+++ b/stubs/resources/views/auth/register.blade.php
@@ -16,14 +16,14 @@
             <div>
                 <x-label for="name" :value="__('Name')" />
 
-                <x-input id="name" class="block mt-1 w-full" type="text" name="name" required autofocus />
+                <x-input id="name" class="block mt-1 w-full" type="text" name="name" value="{{ old('name') }}" required autofocus />
             </div>
 
             <!-- Email Address -->
             <div class="mt-4">
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" required />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required />
             </div>
 
             <!-- Password -->

--- a/stubs/resources/views/auth/reset-password.blade.php
+++ b/stubs/resources/views/auth/reset-password.blade.php
@@ -19,7 +19,7 @@
             <div>
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" required autofocus />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required autofocus />
             </div>
 
             <!-- Password -->


### PR DESCRIPTION
When redirecting the user back after a failed validation (while attempting to register, sign in, or resetting the password), the `name` and `email` fields are now filled with the old values.