### PR TITLE
install alpinejs via npm instead of cdn import

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -31,6 +31,7 @@ class InstallCommand extends Command
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
+                'alpinejs' => '^2.7.3',
                 '@tailwindcss/ui' => '^0.7.2',
                 'postcss-import' => '^12.0.1',
                 'tailwindcss' => '^1.8.0',
@@ -76,6 +77,7 @@ class InstallCommand extends Command
         copy(__DIR__.'/../../stubs/tailwind.config.js', base_path('tailwind.config.js'));
         copy(__DIR__.'/../../stubs/webpack.mix.js', base_path('webpack.mix.js'));
         copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
+        copy(__DIR__.'/../../stubs/resources/js/app.js', resource_path('js/app.js'));
 
         $this->line('');
         $this->info('Breeze scaffolding installed successfully.');

--- a/stubs/resources/js/app.js
+++ b/stubs/resources/js/app.js
@@ -1,0 +1,3 @@
+require('./bootstrap');
+
+require('alpinejs');

--- a/stubs/resources/views/layouts/app.blade.php
+++ b/stubs/resources/views/layouts/app.blade.php
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="{{ asset('css/app.css') }}">
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
+        <script src="{{ asset('js/app.js') }}" defer></script>
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100">

--- a/stubs/resources/views/layouts/guest.blade.php
+++ b/stubs/resources/views/layouts/guest.blade.php
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="{{ asset('css/app.css') }}">
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
+        <script src="{{ asset('js/app.js') }}" defer></script>
     </head>
     <body>
         <div class="font-sans text-gray-900 antialiased">


### PR DESCRIPTION
This PR. allow to use `alpinejs` locally from `npm` instead of import CDN link.