### PR TITLE
[1.x] Fix old value attribute assignement

### DIFF
--- a/stubs/resources/views/auth/forgot-password.blade.php
+++ b/stubs/resources/views/auth/forgot-password.blade.php
@@ -23,7 +23,7 @@
             <div>
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required autofocus />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
             </div>
 
             <div class="flex items-center justify-end mt-4">

--- a/stubs/resources/views/auth/login.blade.php
+++ b/stubs/resources/views/auth/login.blade.php
@@ -19,7 +19,7 @@
             <div>
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required autofocus />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
             </div>
 
             <!-- Password -->

--- a/stubs/resources/views/auth/register.blade.php
+++ b/stubs/resources/views/auth/register.blade.php
@@ -16,14 +16,14 @@
             <div>
                 <x-label for="name" :value="__('Name')" />
 
-                <x-input id="name" class="block mt-1 w-full" type="text" name="name" value="{{ old('name') }}" required autofocus />
+                <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
             </div>
 
             <!-- Email Address -->
             <div class="mt-4">
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required />
             </div>
 
             <!-- Password -->

--- a/stubs/resources/views/auth/reset-password.blade.php
+++ b/stubs/resources/views/auth/reset-password.blade.php
@@ -19,7 +19,7 @@
             <div>
                 <x-label for="email" :value="__('Email')" />
 
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" value="{{ old('email') }}" required autofocus />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
             </div>
 
             <!-- Password -->


### PR DESCRIPTION
`{{ }}` syntax isn't supported on Blade components. 

Fixes https://github.com/laravel/breeze/pull/9