### PR TITLE
[1.x] Improve SPA compatibility

### DIFF
--- a/stubs/App/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/App/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -43,7 +43,7 @@ class AuthenticatedSessionController extends Controller
      */
     public function destroy(Request $request)
     {
-        Auth::logout();
+        Auth::guard('web')->logout();
 
         $request->session()->invalidate();
 

--- a/stubs/App/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/App/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
 
 class ConfirmablePasswordController extends Controller
 {
@@ -24,15 +25,15 @@ class ConfirmablePasswordController extends Controller
      * Confirm the user's password.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @return mixed
      */
     public function store(Request $request)
     {
-        if (! Auth::validate([
+        if (! Auth::guard('web')->validate([
             'email' => $request->user()->email,
             'password' => $request->password,
         ])) {
-            return back()->withErrors([
+            throw ValidationException::withMessages([
                 'password' => __('auth.password'),
             ]);
         }


### PR DESCRIPTION
Just some very minor changes to make the package more SPA compatible out the box:

1. Be explicit with the authentication guard otherwise a SPA will attempt to use the `RequestGuard` and fail.
2. Throw a `ValidationException` if the confirmed password is invalid.

There's of course many ways to implement both points, I've gone with the least amount of change, however:

1. We could type hint the `StatefulGuard` in the constructor like Fortify's [AuthenticatedSessionController](https://github.com/laravel/fortify/blob/1.x/src/Http/Controllers/AuthenticatedSessionController.php#L35) and [ConfirmablePasswordController](https://github.com/laravel/fortify/blob/1.x/src/Http/Controllers/ConfirmablePasswordController.php#L28).
2. We could wrap the exception in an `if ($request->wantsJson()) {` conditional and keep the `back()` redirect for server rendered apps, again like Fortify's [FailedPasswordConfirmationResponse](https://github.com/laravel/fortify/blob/1.x/src/Http/Responses/FailedPasswordConfirmationResponse.php#L21).

Happy to change this request to your preferred implementation if acceptable.

Thanks for your time,
Sam