### PR TITLE
Allow user to specify auth guard and password broker

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\Breeze\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 
 class InstallCommand extends Command
 {
@@ -12,7 +13,7 @@ class InstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'breeze:install';
+    protected $signature = 'breeze:install {guard=web} {passwords=users}';
 
     /**
      * The console command description.
@@ -22,12 +23,97 @@ class InstallCommand extends Command
     protected $description = 'Install the Breeze controllers and resources';
 
     /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * The name of the guard.
+     *
+     * @var string
+     */
+    protected $guardName;
+
+    /**
+     * The name of the password broker.
+     *
+     * @var string
+     */
+    protected $brokerName;
+
+    /**
+     * The controller save path.
+     *
+     * @var string
+     */
+    protected $controllerPath;
+
+    /**
+     * The controller namespace.
+     *
+     * @var string
+     */
+    protected $controllerNamespace;
+
+    /**
+     * The request save path.
+     *
+     * @var string
+     */
+    protected $requestPath;
+
+    /**
+     * The views save path.
+     *
+     * @var string
+     */
+    protected $viewsPath;
+
+    /**
+     * The routes prefix.
+     *
+     * @var string
+     */
+    protected $routePrefix;
+
+    /**
+     * The routes name prefix.
+     *
+     * @var string
+     */
+    protected $routeNamePrefix;
+
+    /**
+     * The guard name to pass to the "guest" middleware.
+     *
+     * @var string
+     */
+    protected $routeGuestGuardName;
+
+    /**
+     * Create a new controller creator command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
      */
     public function handle()
     {
+        $this->setProperties();
+
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
@@ -39,49 +125,219 @@ class InstallCommand extends Command
             ] + $packages;
         });
 
-        // Controllers...
-        (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers/Auth'));
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/App/Http/Controllers/Auth', app_path('Http/Controllers/Auth'));
+        $this->generateControllers();
+        $this->generateRequests();
+        $this->generateRoutes();
+        $this->generateViews();
+        $this->publishAssets();
+        $this->publishTests();
 
-        // Requests...
-        (new Filesystem)->ensureDirectoryExists(app_path('Http/Requests/Auth'));
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/App/Http/Requests/Auth', app_path('Http/Requests/Auth'));
-
-        // Views...
-        (new Filesystem)->ensureDirectoryExists(resource_path('views/auth'));
-        (new Filesystem)->ensureDirectoryExists(resource_path('views/layouts'));
-        (new Filesystem)->ensureDirectoryExists(resource_path('views/components'));
-
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/resources/views/auth', resource_path('views/auth'));
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/resources/views/layouts', resource_path('views/layouts'));
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/resources/views/components', resource_path('views/components'));
-
-        copy(__DIR__.'/../../stubs/resources/views/dashboard.blade.php', resource_path('views/dashboard.blade.php'));
-
-        // Components...
-        (new Filesystem)->ensureDirectoryExists(app_path('View/Components'));
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/App/View/Components', app_path('View/Components'));
-
-        // Tests...
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/tests/Feature', base_path('tests/Feature'));
-
-        // Routes...
-        copy(__DIR__.'/../../stubs/routes/web.php', base_path('routes/web.php'));
-        copy(__DIR__.'/../../stubs/routes/auth.php', base_path('routes/auth.php'));
-
-        // "Dashboard" Route...
-        $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
-        $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));
-        $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
-
-        // Tailwind / Webpack...
-        copy(__DIR__.'/../../stubs/tailwind.config.js', base_path('tailwind.config.js'));
-        copy(__DIR__.'/../../stubs/webpack.mix.js', base_path('webpack.mix.js'));
-        copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
-        copy(__DIR__.'/../../stubs/resources/js/app.js', resource_path('js/app.js'));
+        if ($this->guardName === 'web'){
+            // "Dashboard" Route...
+            $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
+            $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));
+            $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
+        }
 
         $this->info('Breeze scaffolding installed successfully.');
         $this->comment('Please execute the "npm install && npm run dev" command to build your assets.');
+    }
+
+    private function setProperties()
+    {
+        $this->guardName = $this->argument('guard');
+        $this->brokerName = $this->argument('passwords');
+
+        $this->controllerNamespace = ($this->guardName === 'web')
+            ? 'App\Http\Controllers\Auth'
+            : sprintf('App\Http\Controllers\Auth\%s', Str::title($this->guardName));
+
+        $this->controllerPath = ($this->guardName === 'web')
+            ? app_path('Http/Controllers/Auth/')
+            : sprintf(app_path('Http/Controllers/Auth/%s/'), Str::title($this->guardName));
+
+        $this->requestPath = ($this->guardName === 'web')
+            ? app_path('Http/Requests/Auth/')
+            : sprintf(app_path('Http/Requests/Auth/%s/'), Str::title($this->guardName));
+
+        $this->viewsPath = ($this->guardName === 'web')
+            ? resource_path('views')
+            : sprintf(resource_path('views/%s'), Str::lower($this->guardName));
+
+        $this->routePrefix = ($this->guardName === 'web')
+            ? '/'
+            : sprintf('/%s', Str::plural(Str::lower($this->guardName)));
+
+        $this->routeNamePrefix = ($this->guardName === 'web')
+            ? ''
+            : sprintf('%s.', Str::plural(Str::lower($this->guardName)));
+
+        $this->routeGuestGuardName = ($this->guardName === 'web')
+            ? ''
+            : sprintf(':%s', $this->guardName);
+    }
+
+    /**
+     * Generate the authentication library controllers for the given config.
+     *
+     * @return void
+     */
+    protected function generateControllers()
+    {
+        $controllers = [
+            'AuthenticatedSessionController',
+            'ConfirmablePasswordController',
+            'EmailVerificationNotificationController',
+            'EmailVerificationPromptController',
+            'NewPasswordController',
+            'PasswordResetLinkController',
+            'RegisteredUserController',
+            'VerifyEmailController',
+        ];
+
+        $this->files->ensureDirectoryExists($this->controllerPath);
+
+        foreach ($controllers as $controller){
+            $stubPath = realpath(__DIR__.'/../../stubs/App/Http/Controllers/Auth/'.$controller.'.stub');
+            $savePath = $this->controllerPath.$controller.'.php';
+            $this->files->put($savePath, $this->buildClass($stubPath));
+        }
+    }
+
+    /**
+     * Generate the request
+     *
+     * @return void
+     */
+    protected function generateRequests()
+    {
+        $requests = ['LoginRequest'];
+
+        $this->files->ensureDirectoryExists($this->requestPath);
+
+        foreach ($requests as $request){
+            $stubPath = realpath(__DIR__.'/../../stubs/App/Http/Requests/Auth/'.$request.'.stub');
+            $savePath = $this->requestPath.$request.'.php';
+            $this->files->put($savePath, $this->buildClass($stubPath));
+        }
+    }
+
+    /**
+     * Generate the routes, prefixing anf grouping as required.
+     *
+     * @return void
+     */
+    protected function generateRoutes()
+    {
+        $stubPath = realpath(__DIR__.'/../../stubs/routes/auth.php');
+        $savePath = base_path('routes/auth.php');
+        $this->files->put($savePath, $this->buildClass($stubPath));
+
+        $this->files->copy(__DIR__.'/../../stubs/routes/web.php', base_path('routes/web.php'));
+    }
+
+    /**
+     * Generate views that need customisation for guards and route names.
+     *
+     * @return void
+     */
+    protected function generateViews()
+    {
+        $this->copyViews();
+
+        $views = [
+            'auth/confirm-password',
+            'auth/forgot-password',
+            'auth/login',
+            'auth/register',
+            'auth/reset-password',
+            'auth/verify-email',
+            'layouts/navigation',
+        ];
+
+        $this->files->ensureDirectoryExists(sprintf('%s/auth', $this->viewsPath));
+        $this->files->ensureDirectoryExists(sprintf('%s/layouts', $this->viewsPath));
+
+        foreach ($views as $view){
+            $stubPath = realpath(__DIR__.'/../../stubs/resources/views/'.$view.'.blade.php');
+            $savePath = $this->viewsPath.$view.'.blade.php';
+            $this->files->put($savePath, $this->buildClass($stubPath));
+        }
+    }
+
+    /**
+     * Copy all views and view components that do not need to be populated.
+     *
+     * @return void
+     */
+    protected function copyViews()
+    {
+        $this->files->ensureDirectoryExists($this->viewsPath);
+        $this->files->ensureDirectoryExists(resource_path('views/components'));
+        $this->files->copyDirectory(__DIR__.'/../../stubs/resources/views/components', resource_path('views/components'));
+        $this->files->copy(__DIR__.'/../../stubs/resources/views/dashboard.blade.php', sprintf('%s/dashboard.blade.php', $this->viewsPath));
+
+        $this->files->ensureDirectoryExists(app_path('View/Components'));
+        $this->files->copyDirectory(__DIR__.'/../../stubs/App/View/Components', app_path('View/Components'));
+    }
+
+    /**
+     * Publish tailwind and webpack assets.
+     *
+     * @return void
+     */
+    protected function publishAssets()
+    {
+        $this->files->copy(__DIR__.'/../../stubs/tailwind.config.js', base_path('tailwind.config.js'));
+        $this->files->copy(__DIR__.'/../../stubs/webpack.mix.js', base_path('webpack.mix.js'));
+        $this->files->copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
+        $this->files->copy(__DIR__.'/../../stubs/resources/js/app.js', resource_path('js/app.js'));
+    }
+
+    /**
+     * Publish tests.
+     *
+     * @return void
+     */
+    protected function publishTests()
+    {
+        $this->files->copyDirectory(__DIR__.'/../../stubs/tests/Feature', base_path('tests/Feature'));
+    }
+
+    /**
+     * Build the class files by substituting placeholders.
+     *
+     * @param  string  $filePath
+     * @return string
+     */
+    protected function buildClass(string $filePath)
+    {
+        return $this->substitute($this->files->get($filePath));
+    }
+
+    /**
+     * Read the $contents and replace placeholders with real values.
+     *
+     * @param  string  $contents
+     * @return string
+     */
+    protected function substitute(string $contents)
+    {
+        return str_replace([
+            'DummyGuardName',
+            'DummyBrokerName',
+            'DummyControllerNamespace',
+            'DummyRoutePrefix',
+            'DummyRouteNamePrefix',
+            'DummyRouteGuestMiddlewareGuard',
+        ], [
+            $this->guardName,
+            $this->brokerName,
+            $this->controllerNamespace,
+            $this->routePrefix,
+            $this->routeNamePrefix,
+            $this->routeGuestGuardName,
+        ], $contents);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -132,7 +132,7 @@ class InstallCommand extends Command
         $this->publishAssets();
         $this->publishTests();
 
-        if ($this->guardName === 'web'){
+        if ($this->guardName === 'web') {
             // "Dashboard" Route...
             $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
             $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));
@@ -197,7 +197,7 @@ class InstallCommand extends Command
 
         $this->files->ensureDirectoryExists($this->controllerPath);
 
-        foreach ($controllers as $controller){
+        foreach ($controllers as $controller) {
             $stubPath = realpath(__DIR__.'/../../stubs/App/Http/Controllers/Auth/'.$controller.'.stub');
             $savePath = $this->controllerPath.$controller.'.php';
             $this->files->put($savePath, $this->buildClass($stubPath));
@@ -205,7 +205,7 @@ class InstallCommand extends Command
     }
 
     /**
-     * Generate the request
+     * Generate the request.
      *
      * @return void
      */
@@ -215,7 +215,7 @@ class InstallCommand extends Command
 
         $this->files->ensureDirectoryExists($this->requestPath);
 
-        foreach ($requests as $request){
+        foreach ($requests as $request) {
             $stubPath = realpath(__DIR__.'/../../stubs/App/Http/Requests/Auth/'.$request.'.stub');
             $savePath = $this->requestPath.$request.'.php';
             $this->files->put($savePath, $this->buildClass($stubPath));
@@ -258,7 +258,7 @@ class InstallCommand extends Command
         $this->files->ensureDirectoryExists(sprintf('%s/auth', $this->viewsPath));
         $this->files->ensureDirectoryExists(sprintf('%s/layouts', $this->viewsPath));
 
-        foreach ($views as $view){
+        foreach ($views as $view) {
             $stubPath = realpath(__DIR__.'/../../stubs/resources/views/'.$view.'.blade.php');
             $savePath = $this->viewsPath.$view.'.blade.php';
             $this->files->put($savePath, $this->buildClass($stubPath));

--- a/stubs/App/Http/Controllers/Auth/AuthenticatedSessionController.stub
+++ b/stubs/App/Http/Controllers/Auth/AuthenticatedSessionController.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace DummyControllerNamespace;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
@@ -43,7 +43,7 @@ class AuthenticatedSessionController extends Controller
      */
     public function destroy(Request $request)
     {
-        Auth::guard('web')->logout();
+        Auth::guard('DummyGuardName')->logout();
 
         $request->session()->invalidate();
 

--- a/stubs/App/Http/Controllers/Auth/ConfirmablePasswordController.stub
+++ b/stubs/App/Http/Controllers/Auth/ConfirmablePasswordController.stub
@@ -29,7 +29,7 @@ class ConfirmablePasswordController extends Controller
      */
     public function store(Request $request)
     {
-        if (! Auth::guard('web')->validate([
+        if (! Auth::guard('DummyGuardName')->validate([
             'email' => $request->user()->email,
             'password' => $request->password,
         ])) {

--- a/stubs/App/Http/Controllers/Auth/EmailVerificationNotificationController.stub
+++ b/stubs/App/Http/Controllers/Auth/EmailVerificationNotificationController.stub
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class EmailVerificationNotificationController extends Controller
 {
@@ -16,11 +17,11 @@ class EmailVerificationNotificationController extends Controller
      */
     public function store(Request $request)
     {
-        if ($request->user()->hasVerifiedEmail()) {
+        if (Auth::guard('DummyGuardName')->user()->hasVerifiedEmail()) {
             return redirect()->intended(RouteServiceProvider::HOME);
         }
 
-        $request->user()->sendEmailVerificationNotification();
+        Auth::guard('DummyGuardName')->user()->sendEmailVerificationNotification();
 
         return back()->with('status', 'verification-link-sent');
     }

--- a/stubs/App/Http/Controllers/Auth/EmailVerificationPromptController.stub
+++ b/stubs/App/Http/Controllers/Auth/EmailVerificationPromptController.stub
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class EmailVerificationPromptController extends Controller
 {
@@ -16,7 +17,7 @@ class EmailVerificationPromptController extends Controller
      */
     public function __invoke(Request $request)
     {
-        return $request->user()->hasVerifiedEmail()
+        return Auth::guard('DummyGuardName')->user()->hasVerifiedEmail()
                     ? redirect()->intended(RouteServiceProvider::HOME)
                     : view('auth.verify-email');
     }

--- a/stubs/App/Http/Controllers/Auth/NewPasswordController.stub
+++ b/stubs/App/Http/Controllers/Auth/NewPasswordController.stub
@@ -40,7 +40,7 @@ class NewPasswordController extends Controller
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
-        $status = Password::reset(
+        $status = Password::broker('DummyBrokerName')->reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function ($user) use ($request) {
                 $user->forceFill([

--- a/stubs/App/Http/Controllers/Auth/PasswordResetLinkController.stub
+++ b/stubs/App/Http/Controllers/Auth/PasswordResetLinkController.stub
@@ -35,7 +35,7 @@ class PasswordResetLinkController extends Controller
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
-        $status = Password::sendResetLink(
+        $status = Password::broker('DummyBrokerName')->sendResetLink(
             $request->only('email')
         );
 

--- a/stubs/App/Http/Controllers/Auth/RegisteredUserController.stub
+++ b/stubs/App/Http/Controllers/Auth/RegisteredUserController.stub
@@ -38,7 +38,7 @@ class RegisteredUserController extends Controller
             'password' => 'required|string|confirmed|min:8',
         ]);
 
-        Auth::login($user = User::create([
+        Auth::guard('DummyGuardName')->login($user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),

--- a/stubs/App/Http/Controllers/Auth/VerifyEmailController.stub
+++ b/stubs/App/Http/Controllers/Auth/VerifyEmailController.stub
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Support\Facades\Auth;
 
 class VerifyEmailController extends Controller
 {
@@ -17,12 +18,12 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request)
     {
-        if ($request->user()->hasVerifiedEmail()) {
+        if (Auth::guard('DummyGuardName')->user()->hasVerifiedEmail()) {
             return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');
         }
 
-        if ($request->user()->markEmailAsVerified()) {
-            event(new Verified($request->user()));
+        if (Auth::guard('DummyGuardName')->user()->markEmailAsVerified()) {
+            event(new Verified(Auth::guard('DummyGuardName')->user()));
         }
 
         return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');

--- a/stubs/App/Http/Requests/Auth/LoginRequest.stub
+++ b/stubs/App/Http/Requests/Auth/LoginRequest.stub
@@ -12,6 +12,13 @@ use Illuminate\Validation\ValidationException;
 class LoginRequest extends FormRequest
 {
     /**
+     * The name of the guard this request is using.
+     *
+     * @var string
+     */
+    protected $guardName = 'DummyGuardName';
+
+    /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
@@ -45,7 +52,7 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->filled('remember'))) {
+        if (! Auth::guard($this->guardName)->attempt($this->only('email', 'password'), $this->filled('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
@@ -88,6 +95,11 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey()
     {
-        return Str::lower($this->input('email')).'|'.$this->ip();
+        return Str::lower(sprintf(
+            '%s|%s|%s',
+            $this->input('email'),
+            $this->ip(),
+            $this->guardName
+        ));
     }
 }

--- a/stubs/resources/views/auth/confirm-password.blade.php
+++ b/stubs/resources/views/auth/confirm-password.blade.php
@@ -13,7 +13,7 @@
         <!-- Validation Errors -->
         <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
-        <form method="POST" action="{{ route('password.confirm') }}">
+        <form method="POST" action="{{ route('DummyRouteNamePrefixpassword.confirm') }}">
             @csrf
 
             <!-- Password -->

--- a/stubs/resources/views/auth/forgot-password.blade.php
+++ b/stubs/resources/views/auth/forgot-password.blade.php
@@ -16,7 +16,7 @@
         <!-- Validation Errors -->
         <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
-        <form method="POST" action="{{ route('password.email') }}">
+        <form method="POST" action="{{ route('DummyRouteNamePrefixpassword.email') }}">
             @csrf
 
             <!-- Email Address -->

--- a/stubs/resources/views/auth/login.blade.php
+++ b/stubs/resources/views/auth/login.blade.php
@@ -12,7 +12,7 @@
         <!-- Validation Errors -->
         <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
-        <form method="POST" action="{{ route('login') }}">
+        <form method="POST" action="{{ route('DummyRouteNamePrefixlogin') }}">
             @csrf
 
             <!-- Email Address -->
@@ -42,7 +42,7 @@
 
             <div class="flex items-center justify-end mt-4">
                 @if (Route::has('password.request'))
-                    <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
+                    <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('DummyRouteNamePrefixpassword.request') }}">
                         {{ __('Forgot your password?') }}
                     </a>
                 @endif

--- a/stubs/resources/views/auth/register.blade.php
+++ b/stubs/resources/views/auth/register.blade.php
@@ -9,7 +9,7 @@
         <!-- Validation Errors -->
         <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
-        <form method="POST" action="{{ route('register') }}">
+        <form method="POST" action="{{ route('DummyRouteNamePrefixregister') }}">
             @csrf
 
             <!-- Name -->
@@ -46,7 +46,7 @@
             </div>
 
             <div class="flex items-center justify-end mt-4">
-                <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('login') }}">
+                <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('DummyRouteNamePrefixlogin') }}">
                     {{ __('Already registered?') }}
                 </a>
 

--- a/stubs/resources/views/auth/reset-password.blade.php
+++ b/stubs/resources/views/auth/reset-password.blade.php
@@ -9,7 +9,7 @@
         <!-- Validation Errors -->
         <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
-        <form method="POST" action="{{ route('password.update') }}">
+        <form method="POST" action="{{ route('DummyRouteNamePrefixpassword.update') }}">
             @csrf
 
             <!-- Password Reset Token -->

--- a/stubs/resources/views/auth/verify-email.blade.php
+++ b/stubs/resources/views/auth/verify-email.blade.php
@@ -17,7 +17,7 @@
         @endif
 
         <div class="mt-4 flex items-center justify-between">
-            <form method="POST" action="{{ route('verification.send') }}">
+            <form method="POST" action="{{ route('DummyRouteNamePrefixverification.send') }}">
                 @csrf
 
                 <div>

--- a/stubs/resources/views/layouts/navigation.blade.php
+++ b/stubs/resources/views/layouts/navigation.blade.php
@@ -5,14 +5,14 @@
             <div class="flex">
                 <!-- Logo -->
                 <div class="flex-shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
+                    <a href="{{ route('DummyRouteNamePrefixdashboard') }}">
                         <x-application-logo class="block h-10 w-auto fill-current text-gray-600" />
                     </a>
                 </div>
 
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+                    <x-nav-link :href="route('DummyRouteNamePrefixdashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
                 </div>
@@ -23,7 +23,7 @@
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
-                            <div>{{ Auth::user()->name }}</div>
+                            <div>{{ Auth::guard('DummyGuardName')->user()->name }}</div>
 
                             <div class="ml-1">
                                 <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -35,10 +35,10 @@
 
                     <x-slot name="content">
                         <!-- Authentication -->
-                        <form method="POST" action="{{ route('logout') }}">
+                        <form method="POST" action="{{ route('DummyRouteNamePrefixlogout') }}">
                             @csrf
 
-                            <x-dropdown-link :href="route('logout')"
+                            <x-dropdown-link :href="route('DummyRouteNamePrefixlogout')"
                                     onclick="event.preventDefault();
                                                 this.closest('form').submit();">
                                 {{ __('Logout') }}
@@ -63,7 +63,7 @@
     <!-- Responsive Navigation Menu -->
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+            <x-responsive-nav-link :href="route('DummyRouteNamePrefixdashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
         </div>
@@ -78,17 +78,17 @@
                 </div>
 
                 <div class="ml-3">
-                    <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                    <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
+                    <div class="font-medium text-base text-gray-800">{{ Auth::guard('DummyGuardName')->user()->name }}</div>
+                    <div class="font-medium text-sm text-gray-500">{{ Auth::guard('DummyGuardName')->user()->email }}</div>
                 </div>
             </div>
 
             <div class="mt-3 space-y-1">
                 <!-- Authentication -->
-                <form method="POST" action="{{ route('logout') }}">
+                <form method="POST" action="{{ route('DummyRouteNamePrefixlogout') }}">
                     @csrf
 
-                    <x-responsive-nav-link :href="route('logout')"
+                    <x-responsive-nav-link :href="route('DummyRouteNamePrefixlogout')"
                             onclick="event.preventDefault();
                                         this.closest('form').submit();">
                         {{ __('Logout') }}

--- a/stubs/routes/auth.php
+++ b/stubs/routes/auth.php
@@ -1,64 +1,58 @@
 <?php
 
-use App\Http\Controllers\Auth\AuthenticatedSessionController;
-use App\Http\Controllers\Auth\ConfirmablePasswordController;
-use App\Http\Controllers\Auth\EmailVerificationNotificationController;
-use App\Http\Controllers\Auth\EmailVerificationPromptController;
-use App\Http\Controllers\Auth\NewPasswordController;
-use App\Http\Controllers\Auth\PasswordResetLinkController;
-use App\Http\Controllers\Auth\RegisteredUserController;
-use App\Http\Controllers\Auth\VerifyEmailController;
+use DummyControllerNamespace\AuthenticatedSessionController;
+use DummyControllerNamespace\ConfirmablePasswordController;
+use DummyControllerNamespace\EmailVerificationNotificationController;
+use DummyControllerNamespace\EmailVerificationPromptController;
+use DummyControllerNamespace\NewPasswordController;
+use DummyControllerNamespace\PasswordResetLinkController;
+use DummyControllerNamespace\RegisteredUserController;
+use DummyControllerNamespace\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/register', [RegisteredUserController::class, 'create'])
-                ->middleware('guest')
-                ->name('register');
+Route::prefix('DummyRoutePrefix')->group(function(){
+    Route::middleware('guestDummyRouteGuestMiddlewareGuard')->group(function(){
+        Route::get('/register', [RegisteredUserController::class, 'create'])
+            ->name('DummyRouteNamePrefixregister');
 
-Route::post('/register', [RegisteredUserController::class, 'store'])
-                ->middleware('guest');
+        Route::post('/register', [RegisteredUserController::class, 'store']);
 
-Route::get('/login', [AuthenticatedSessionController::class, 'create'])
-                ->middleware('guest')
-                ->name('login');
+        Route::get('/login', [AuthenticatedSessionController::class, 'create'])
+            ->name('DummyRouteNamePrefixlogin');
 
-Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-                ->middleware('guest');
+        Route::post('/login', [AuthenticatedSessionController::class, 'store']);
 
-Route::get('/forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->middleware('guest')
-                ->name('password.request');
+        Route::get('/forgot-password', [PasswordResetLinkController::class, 'create'])
+            ->name('DummyRouteNamePrefixpassword.request');
 
-Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.email');
+        Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
+            ->name('DummyRouteNamePrefixpassword.email');
 
-Route::get('/reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->middleware('guest')
-                ->name('password.reset');
+        Route::get('/reset-password/{token}', [NewPasswordController::class, 'create'])
+            ->name('DummyRouteNamePrefixpassword.reset');
 
-Route::post('/reset-password', [NewPasswordController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.update');
+        Route::post('/reset-password', [NewPasswordController::class, 'store'])
+            ->name('DummyRouteNamePrefixpassword.update');
+    });
 
-Route::get('/verify-email', [EmailVerificationPromptController::class, '__invoke'])
-                ->middleware('auth')
-                ->name('verification.notice');
+    Route::middleware('authDummyRouteGuestMiddlewareGuard')->group(function(){
+        Route::get('/verify-email', [EmailVerificationPromptController::class, '__invoke'])
+            ->name('DummyRouteNamePrefixverification.notice');
 
-Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-                ->middleware(['auth', 'signed', 'throttle:6,1'])
-                ->name('verification.verify');
+        Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+            ->middleware(['signed', 'throttle:6,1'])
+            ->name('DummyRouteNamePrefixverification.verify');
 
-Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware(['auth', 'throttle:6,1'])
-                ->name('verification.send');
+        Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+            ->middleware(['throttle:6,1'])
+            ->name('DummyRouteNamePrefixverification.send');
 
-Route::get('/confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->middleware('auth')
-                ->name('password.confirm');
+        Route::get('/confirm-password', [ConfirmablePasswordController::class, 'show'])
+            ->name('DummyRouteNamePrefixpassword.confirm');
 
-Route::post('/confirm-password', [ConfirmablePasswordController::class, 'store'])
-                ->middleware('auth');
+        Route::post('/confirm-password', [ConfirmablePasswordController::class, 'store']);
 
-Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->middleware('auth')
-                ->name('logout');
+        Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+            ->name('DummyRouteNamePrefixlogout');
+    });
+});

--- a/stubs/routes/auth.php
+++ b/stubs/routes/auth.php
@@ -10,8 +10,8 @@ use DummyControllerNamespace\RegisteredUserController;
 use DummyControllerNamespace\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('DummyRoutePrefix')->group(function(){
-    Route::middleware('guestDummyRouteGuestMiddlewareGuard')->group(function(){
+Route::prefix('DummyRoutePrefix')->group(function () {
+    Route::middleware('guestDummyRouteGuestMiddlewareGuard')->group(function () {
         Route::get('/register', [RegisteredUserController::class, 'create'])
             ->name('DummyRouteNamePrefixregister');
 
@@ -35,7 +35,7 @@ Route::prefix('DummyRoutePrefix')->group(function(){
             ->name('DummyRouteNamePrefixpassword.update');
     });
 
-    Route::middleware('authDummyRouteGuestMiddlewareGuard')->group(function(){
+    Route::middleware('authDummyRouteGuestMiddlewareGuard')->group(function () {
         Route::get('/verify-email', [EmailVerificationPromptController::class, '__invoke'])
             ->name('DummyRouteNamePrefixverification.notice');
 


### PR DESCRIPTION
For your consideration, I have taken inspiration from existing generators in Laravel to extend Breeze so that the user may pass in two arguments to specify the auth guard and password broker they wish to use. 

```bash
php artisan breeze:install 
php artisan breeze:install web users # same as above
php artisan breeze:install members members
```

In its current state, Breeze is hard-coded to support the default guard/password. While this is helpful and not too difficult to edit if required, I think it is helpful to be able to scaffold auth for a different guard as easily as the defaults. 

Naturally, the default values of the new arguments ("guard" and "passwords") are "web" and "users" respectively. 
I have therefore only set route prefixes, namespaces etc. if these arguments are not default. Much of this can be seen in the `setProperties` method. 

Unlike other Laravel generator commands, `breeze:install` was simply copying files from a stubs directory to the matching project directories. As this PR considers the user's input, we are substituting strings so I have tried to conform with past Laravel instances a renamed the stub files from `.php` files to `.stub` - I don't think this makes much difference, just preference and style. 

Obviously docs will need to be updated to reflect that the user can define their own guard/broker and that they should pass *both* arguments. 
I had considered a scenario where the user was able to pass only one argument (likely the guard) and we assumed the broker was defined with the same name but this seems unlikely and could cause confusion later. 

I have not updated tests yet as I wanted to offer this first to see if there's interest. If there is I would likely create a `MemberFactory` and local `Member` model to test against `php artisan breeze:install members members`. The tests would mostly be amended copies of the existing ones. 

The benefit to the end user is more customisable auth scaffolding in the event they wish to add an authenticated area to their application for more than just `users`. 
An additional benefit is the clearer configuration of the `Auth` and `Password` facades as both the `guard` and `broker` methods are now used even if using the default auth config. 

Happy to make amendments as directed. 
