### PR TITLE
fix: update status code for request that could not be authenticated

### DIFF
--- a/stubs/App/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/App/Http/Requests/Auth/LoginRequest.php
@@ -50,7 +50,7 @@ class LoginRequest extends FormRequest
 
             throw ValidationException::withMessages([
                 'email' => __('auth.failed'),
-            ]);
+            ])->status(401);
         }
 
         RateLimiter::clear($this->throttleKey());


### PR DESCRIPTION
The HTTP [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) client error status response code indicates that the request has not been applied because it lacks valid authentication credentials for the target resource.
