### PR TITLE
[1.x] Use named route for email verification screen in feature test stub

### DIFF
--- a/stubs/tests/Feature/EmailVerificationTest.php
+++ b/stubs/tests/Feature/EmailVerificationTest.php
@@ -20,7 +20,7 @@ class EmailVerificationTest extends TestCase
             'email_verified_at' => null,
         ]);
 
-        $response = $this->actingAs($user)->get('/verify-email');
+        $response = $this->actingAs($user)->get(route('verification.notice'));
 
         $response->assertStatus(200);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Email verification page url is currently hardcoded in `stubs/tests/Feature/EmailVerificationTest.php`. This PR makes use of the `verification.notice` named route.