### PR TITLE
[1.x] Redirect to intended path after login

### DIFF
--- a/stubs/App/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/App/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -32,7 +32,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect(RouteServiceProvider::HOME);
+        return redirect()->intended(RouteServiceProvider::HOME);
     }
 
     /**


### PR DESCRIPTION
Had some users complaining that email verification was not working properly in some cases.
For example on ios, when a user clicks the verification link, link is opened in a new window without any sessions.
The `auth` middleware will now prevent the email verification process since the user is not logged in.

This minor fix ensures a redirect to the intended page after login. In this example, back to verification link after login, which works fine now.

Without this fix users would be redirected to the `/verify-mail` page after login (depending on the `verified` middleware), with the option to resend the verification mail. This process will then be repeated over and over.

This should also fix the situation registration on device A, validation on device B (which has no active session)
