### PR TITLE
Add @inertiajs/progress to package dependencies

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -108,7 +108,7 @@ class InstallCommand extends Command
             return [
                 '@inertiajs/inertia' => '^0.8.4',
                 '@inertiajs/inertia-vue3' => '^0.3.5',
-                '@inertiajs/progress": "^0.2.4',
+                '@inertiajs/progress': '^0.2.4',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@vue/compiler-sfc' => '^3.0.5',
                 'autoprefixer' => '^10.2.4',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -108,6 +108,7 @@ class InstallCommand extends Command
             return [
                 '@inertiajs/inertia' => '^0.8.4',
                 '@inertiajs/inertia-vue3' => '^0.3.5',
+                '@inertiajs/progress": "^0.2.4',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@vue/compiler-sfc' => '^3.0.5',
                 'autoprefixer' => '^10.2.4',

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -3,6 +3,7 @@ require('./bootstrap');
 // Import modules...
 import { createApp, h } from 'vue';
 import { App as InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue3';
+import { InertiaProgress } from '@inertiajs/progress'
 
 const el = document.getElementById('app');
 
@@ -16,3 +17,11 @@ createApp({
     .mixin({ methods: { route } })
     .use(InertiaPlugin)
     .mount(el);
+
+
+InertiaProgress.init({
+    delay: 250,
+    color: '#F05340',
+    includeCSS: true,
+    showSpinner: false,
+});

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -20,7 +20,7 @@ createApp({
 
 InertiaProgress.init({
     delay: 250,
-    color: '#F05340',
+    color: '#4B5563',
     includeCSS: true,
     showSpinner: false,
 });

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -18,7 +18,6 @@ createApp({
     .use(InertiaPlugin)
     .mount(el);
 
-
 InertiaProgress.init({
     delay: 250,
     color: '#F05340',


### PR DESCRIPTION
This PR adds Inertia Progress to the base scaffold and uses the Laravel orange hex #F05340 for the progress bar.

![image](https://user-images.githubusercontent.com/228899/108279004-c147a900-7130-11eb-825f-b49655d5b03f.png)

