### PR TITLE
[1.x] Simplify Inertia progress

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -18,9 +18,4 @@ createApp({
     .use(InertiaPlugin)
     .mount(el);
 
-InertiaProgress.init({
-    delay: 250,
-    color: '#4B5563',
-    includeCSS: true,
-    showSpinner: false,
-});
+InertiaProgress.init({ color: '#4B5563' });


### PR DESCRIPTION
I just came here to add the Inertia progress bar, and was happy to see that @ninjaparade beat me to it! 😍

That said, I think it might be better to leave the `delay`, `includeCSS` and `showSpinner` out, and let them fallback to the defaults. Most projects don't need to touch those settings, IMHO.