### PR TITLE
[1.x] Fix unexpected ':' in key-value array

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -108,7 +108,7 @@ class InstallCommand extends Command
             return [
                 '@inertiajs/inertia' => '^0.8.4',
                 '@inertiajs/inertia-vue3' => '^0.3.5',
-                '@inertiajs/progress': '^0.2.4',
+                '@inertiajs/progress' => '^0.2.4',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@vue/compiler-sfc' => '^3.0.5',
                 'autoprefixer' => '^10.2.4',


### PR DESCRIPTION
This fixes a bug introduced in #46, which is currently causing the `php artisan breeze:install --inertia` call to fail:

```
 ✝ ~/Code/claudiodekker/test-breeze  master±  php artisan breeze:install --inertia

   ParseError

  syntax error, unexpected ':', expecting ']'

  at /Users/claudiodekker/Code/claudiodekker/breeze/src/Console/InstallCommand.php:111
    107▕         $this->updateNodePackages(function ($packages) {
    108▕             return [
    109▕                 '@inertiajs/inertia' => '^0.8.4',
    110▕                 '@inertiajs/inertia-vue3' => '^0.3.5',
  ➜ 111▕                 '@inertiajs/progress': '^0.2.4',
    112▕                 '@tailwindcss/forms' => '^0.2.1',
```