### PR TITLE
Fixes Vue warning

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -55,10 +55,10 @@
         },
 
         props: {
-            canResetPassword: Boolean,
-            status: String,
-            errors: Object,
             auth: Object,
+            canResetPassword: Boolean,
+            errors: Object,
+            status: String,
         },
 
         data() {

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -56,7 +56,9 @@
 
         props: {
             canResetPassword: Boolean,
-            status: String
+            status: String,
+            errors: Object,
+            auth: Object,
         },
 
         data() {


### PR DESCRIPTION
Added errors and auth props to get rid of this Vue warning: [Vue warn]: Extraneous non-props attributes (errors, auth) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. See: https://inertiajs.com/validation#displaying-errors. I guess this error is caused by a layout feature/bug in Inertia, so it might be solved by Inertiajs in the future. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
