### PR TITLE
Fix return type for phpstan

### DIFF
--- a/stubs/default/App/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/default/App/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -12,7 +12,7 @@ class EmailVerificationNotificationController extends Controller
      * Send a new email verification notification.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(Request $request)
     {


### PR DESCRIPTION
Updating the return type in `EmailVerificationNotificationController` to `\Illuminate\Http\RedirectResponse` after receiving the following errors from phpstan:

```
vendor/bin/phpstan analyse --memory-limit 4G -c phpstan.neon app tests
 43/43 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   app/Http/Controllers/Auth/EmailVerificationNotificationController.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  19     Method App\Http\Controllers\Auth\EmailVerificationNotificationController::store() should return Illuminate\Http\Response but returns Illuminate\Http\RedirectResponse.
  24     Method App\Http\Controllers\Auth\EmailVerificationNotificationController::store() should return Illuminate\Http\Response but returns Illuminate\Http\RedirectResponse.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------


 [ERROR] Found 2 errors
```