### PR TITLE
Add more robust test for registration flow

### DIFF
--- a/stubs/default/tests/Feature/AuthenticationTest.php
+++ b/stubs/default/tests/Feature/AuthenticationTest.php
@@ -5,11 +5,13 @@ namespace Tests\Feature;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
 {
     use RefreshDatabase;
+    use WithFaker;
 
     public function test_login_screen_can_be_rendered()
     {
@@ -41,5 +43,30 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertGuest();
+    }
+    
+    public function test_users_can_register_and_then_authenticate_using_the_login_screen()
+    {
+        $newUserEmail = $this->faker->unique()->safeEmail;
+
+        $this->post('/register', [
+            'email' => $newUserEmail,
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $this->app['auth']->logout();
+
+        $this->assertGuest();
+
+        $user = Person::where('email', $newUserEmail)->first();
+
+        $response = $this->post('/login', [
+            'email' => $newUserEmail,
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(route('person.edit', $user));
     }
 }


### PR DESCRIPTION
Add the `test_users_can_register_and_then_authenticate_using_the_login_screen()` method to ensure a user can register and then log in.

**More information**
The current suite tests to see if a user can register and if another user can login. It does not test if a user can register and _then_ login. Consider a situation where the developer has accidentally left `'password'` out of the User model `$fillable` array. All tests would pass successfully, but the app would be fundamentally broken.

This adds a more robust authentication test in situations where it's possible to collect a user's email address without a password (eg. an SCV which include mailing list subscription information). As happened to me today.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
