### PR TITLE
Fix Login event firing before Register

### DIFF
--- a/stubs/default/App/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/default/App/Http/Controllers/Auth/RegisteredUserController.php
@@ -38,13 +38,15 @@ class RegisteredUserController extends Controller
             'password' => 'required|string|confirmed|min:8',
         ]);
 
-        Auth::login($user = User::create([
+        $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-        ]));
+        ]);
 
         event(new Registered($user));
+
+        Auth::login($user);
 
         return redirect(RouteServiceProvider::HOME);
     }

--- a/stubs/inertia/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -39,13 +39,15 @@ class RegisteredUserController extends Controller
             'password' => 'required|string|confirmed|min:8',
         ]);
 
-        Auth::login($user = User::create([
+        $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-        ]));
+        ]);
 
         event(new Registered($user));
+
+        Auth::login($user);
 
         return redirect(RouteServiceProvider::HOME);
     }


### PR DESCRIPTION
This fixes the wrong order of events firing on user registration. It was caused by the Auth::login() happening before firing the Registered event.

Order before: Login event, then Register event.  
Order now: Register event, then Login event.

This could have possibly caused confusion and problems for apps that rely on the events firing in the correct order, which is the same as what happens in reality: user is first registered, and only then can the user login.