### PR TITLE
Fix Vue warning

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -36,6 +36,11 @@
             BreezeValidationErrors,
         },
 
+        props: {
+            auth: Object,
+            errors: Object,
+        },
+
         data() {
             return {
                 form: this.$inertia.form({

--- a/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
@@ -41,7 +41,9 @@
         },
 
         props: {
-            status: String
+            auth: Object,
+            errors: Object,
+            status: String,
         },
 
         data() {

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -51,6 +51,11 @@
             BreezeValidationErrors,
         },
 
+        props: {
+            auth: Object,
+            errors: Object,
+        },
+
         data() {
             return {
                 form: this.$inertia.form({

--- a/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
@@ -43,7 +43,9 @@
         },
 
         props: {
+            auth: Object,
             email: String,
+            errors: Object,
             token: String,
         },
 

--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -30,7 +30,9 @@
         },
 
         props: {
-            status: String
+            auth: Object,
+            errors: Object,
+            status: String,
         },
 
         data() {

--- a/stubs/inertia/resources/js/Pages/Dashboard.vue
+++ b/stubs/inertia/resources/js/Pages/Dashboard.vue
@@ -25,5 +25,10 @@
         components: {
             BreezeAuthenticatedLayout,
         },
+
+        props: {
+            auth: Object,
+            errors: Object,
+        },
     }
 </script>

--- a/stubs/inertia/resources/js/Pages/Welcome.vue
+++ b/stubs/inertia/resources/js/Pages/Welcome.vue
@@ -177,8 +177,10 @@
 <script>
     export default {
         props: {
+            auth: Object,
             canLogin: Boolean,
             canRegister: Boolean,
+            errors: Object,
             laravelVersion: String,
             phpVersion: String,
         }


### PR DESCRIPTION
When visiting forgot-password page there is a console [Vue warn]: Extraneous non-props attributes (errors, auth) were passed to component but could not be automatically inherited because component renders fragment or text root nodes.
The reason is [Attribute Inheritance on Multiple Root Nodes](https://v3.vuejs.org/guide/component-attrs.html#attribute-inheritance-on-multiple-root-nodes)

Inertia shares `errors` as a prop by default and Breeze shares `auth` as a prop by default. If those props are not explicitly defined on each page component a Vue runtime warning will be issued.

We can wrap all the root nodes of the page component in a `<div>` to create a single root component and get rid of the warning, But those props will be inherited as [Non-Prop Attributes](https://v3.vuejs.org/guide/component-attrs.html#non-prop-attributes) resulting in `<div errors="[object Object]" auth="[object Object]">`

Suggested solution : explicitly define `errors` and `auth` as props on each page component.