### PR TITLE
[1.x] Add `jsconfig.js`

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -161,6 +161,7 @@ class InstallCommand extends Command
         copy(__DIR__.'/../../stubs/inertia/tailwind.config.js', base_path('tailwind.config.js'));
         copy(__DIR__.'/../../stubs/inertia/webpack.mix.js', base_path('webpack.mix.js'));
         copy(__DIR__.'/../../stubs/inertia/webpack.config.js', base_path('webpack.config.js'));
+        copy(__DIR__.'/../../stubs/inertia/jsconfig.json', base_path('jsconfig.json'));
         copy(__DIR__.'/../../stubs/inertia/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/inertia/resources/js/app.js', resource_path('js/app.js'));
 

--- a/stubs/inertia/jsconfig.json
+++ b/stubs/inertia/jsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["resources/js/*"]
+        }
+    },
+    "exclude": ["node_modules", "public"]
+}


### PR DESCRIPTION
This PR adds a `jsconfig.json` file to the Inertia scaffolding to allow javascript services in VSCode to allow better support for the `@` alias. 

More information about the `jsconfig.json` file can be read (here)[https://code.visualstudio.com/docs/languages/jsconfig]

![image](https://user-images.githubusercontent.com/228899/116488947-85277780-a848-11eb-8533-126f3be52564.png)
