### PR TITLE
[1.x] Bump Inertia version to match Spark

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -101,7 +101,7 @@ class InstallCommand extends Command
     protected function installInertiaStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3.5', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.4.1', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
 
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {


### PR DESCRIPTION
Currently you can not install Breeze along side Spark due to version conflicts. 

Spark requires `^0.4.1` where as Breeze is at `^0.3.5`