### PR TITLE
[1.x] Change as from 'a' to 'button'

### DIFF
--- a/stubs/inertia-react/resources/js/Components/ResponsiveNavLink.js
+++ b/stubs/inertia-react/resources/js/Components/ResponsiveNavLink.js
@@ -1,7 +1,7 @@
 import { InertiaLink } from '@inertiajs/inertia-react';
 import React from 'react';
 
-export default function ResponsiveNavLink({ method = 'get', as = 'a', href, active = false, children }) {
+export default function ResponsiveNavLink({ method = 'get', as = 'button', href, active = false, children }) {
     return (
         <InertiaLink
             method={method}


### PR DESCRIPTION
https://inertiajs.com/links
Links are suggested to be "button" rather than "a"

Otherwise, a warning will show by default.

@reinink FYI thoughts?