### PR TITLE
remove double session regeneration

### DIFF
--- a/stubs/default/App/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/default/App/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -30,8 +30,6 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
-        $request->session()->regenerate();
-
         return redirect()->intended(RouteServiceProvider::HOME);
     }
 

--- a/stubs/inertia-common/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -35,8 +35,6 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
-        $request->session()->regenerate();
-
         return redirect()->intended(RouteServiceProvider::HOME);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

On login, the session is regenerated twice. The second time appears to be unnecessary and means if you try to capture the user's session ID on the `Illuminate\Auth\Events\Login` event, it is not the right one.

The first regeneration happens in the `SessionGuard` login, it calls `UpdateSession` - https://github.com/laravel/framework/blob/6.x/src/Illuminate/Auth/SessionGuard.php#L450