### PR TITLE
[1.x] Fix CORS policy errors with inertia stack

### DIFF
--- a/stubs/inertia-common/resources/views/app.blade.php
+++ b/stubs/inertia-common/resources/views/app.blade.php
@@ -19,5 +19,9 @@
     </head>
     <body class="font-sans antialiased">
         @inertia
+
+        @env ('local')
+            <script src="http://localhost:3000/browser-sync/browser-sync-client.js"></script>
+        @endenv
     </body>
 </html>


### PR DESCRIPTION
## Description

### Quick note

this pull request reflects the same change that has jetstream on inertia stack that is already merged <a target="_blank" href="https://github.com/laravel/jetstream/pull/797">fix cors policy errors with inertia stack #797</a>

<hr/>

on inertia stack a when you run `npm install && npm run watch` if you work with `.test` domains like Laravel Valet add, the watcher does not add live reload with `browserSync` you must work with `localhost` ip to work with vue components.

to avoid this by adding this tag on `app.blade.php` file on inertia stack it would reload `.test` domains as it is a `localhost` domain.

## How it help the end user

it avoid confusion on why vue components does not reload using browserSync by default, and make easier the workflow with inertia and of course with jetstream.
