### PR TITLE
Fix EmailVerificationTest to pass using Uuids

### DIFF
--- a/stubs/default/tests/Feature/EmailVerificationTest.php
+++ b/stubs/default/tests/Feature/EmailVerificationTest.php
@@ -27,11 +27,11 @@ class EmailVerificationTest extends TestCase
 
     public function test_email_can_be_verified()
     {
-        Event::fake();
-
         $user = User::factory()->create([
             'email_verified_at' => null,
         ]);
+        
+        Event::fake();
 
         $verificationUrl = URL::temporarySignedRoute(
             'verification.verify',


### PR DESCRIPTION
Most of the solutions to use UUIDs as primary key for models relies on Eloquent events.
The Breeze email verification's test fakes the Event bus before a fake user is created, so if you're going to use an event based solution for generating uuid it will fail while trying to create the user (integrity constraint on SQL).
The solution should be quite easy: creating the user before start faking the event bus.

Sorry if I've missed something, this is my very first PR! 😊 
