### PR TITLE
Add dynamic page title to layout components

### DIFF
--- a/stubs/default/App/View/Components/AppLayout.php
+++ b/stubs/default/App/View/Components/AppLayout.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class AppLayout extends Component
+class AppLayout extends Layout
 {
     /**
      * Get the view / contents that represents the component.

--- a/stubs/default/App/View/Components/GuestLayout.php
+++ b/stubs/default/App/View/Components/GuestLayout.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class GuestLayout extends Component
+class GuestLayout extends Layout
 {
     /**
      * Get the view / contents that represents the component.

--- a/stubs/default/App/View/Components/Layout.php
+++ b/stubs/default/App/View/Components/Layout.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Support\Arr;
+use Illuminate\View\Component;
+
+abstract class Layout extends Component
+{
+    public $title;
+
+    protected $seperator = '|';
+
+    public function __construct($title = null)
+    {
+        $title = Arr::wrap($title);
+
+        $title[] = config('app.name', 'Laravel');
+
+        $this->title = implode(" {$this->seperator} ", $title);
+    }
+
+    abstract public function render();
+}

--- a/stubs/default/resources/views/auth/confirm-password.blade.php
+++ b/stubs/default/resources/views/auth/confirm-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout :title="__('Confirm Password')">
     <x-auth-card>
         <x-slot name="logo">
             <a href="/">

--- a/stubs/default/resources/views/auth/forgot-password.blade.php
+++ b/stubs/default/resources/views/auth/forgot-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout :title="__('Forgot Password')">
     <x-auth-card>
         <x-slot name="logo">
             <a href="/">

--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout :title="__('Login')">
     <x-auth-card>
         <x-slot name="logo">
             <a href="/">

--- a/stubs/default/resources/views/auth/register.blade.php
+++ b/stubs/default/resources/views/auth/register.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout :title="__('Register')">
     <x-auth-card>
         <x-slot name="logo">
             <a href="/">

--- a/stubs/default/resources/views/auth/reset-password.blade.php
+++ b/stubs/default/resources/views/auth/reset-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout :title="__('Reset Password')">
     <x-auth-card>
         <x-slot name="logo">
             <a href="/">

--- a/stubs/default/resources/views/auth/verify-email.blade.php
+++ b/stubs/default/resources/views/auth/verify-email.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout :title="__('Verify Email')">
     <x-auth-card>
         <x-slot name="logo">
             <a href="/">

--- a/stubs/default/resources/views/dashboard.blade.php
+++ b/stubs/default/resources/views/dashboard.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout :title="__('Dashboard')">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Dashboard') }}

--- a/stubs/default/resources/views/layouts/app.blade.php
+++ b/stubs/default/resources/views/layouts/app.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        <title>{{ $title }}</title>
 
         <!-- Fonts -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">

--- a/stubs/default/resources/views/layouts/guest.blade.php
+++ b/stubs/default/resources/views/layouts/guest.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        <title>{{ $title }}</title>
 
         <!-- Fonts -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">


### PR DESCRIPTION
All of the default pages in Breeze have the same title which [isn't very accessible](https://www.w3.org/WAI/tips/writing/#provide-informative-unique-page-titles). I've updated the the Guest and App layouts to support a `title` prop so developers can set a unique page title. I think this will encourage better templating practices. The abstract Layout component I added also serves as a good place to define site-wide layout behavior.

The `title` prop accepts a `string` or `array` and automatically appends the App Name to the end of the page title:
`'Login'` becomes "Login | Laravel" and `['Child Page', 'Parent Page']` becomes "Child Page | Parent Page | Laravel".