### PR TITLE
Add Vue file extension to all Vue components imported

### DIFF
--- a/stubs/inertia-vue/resources/js/Components/Dropdown.vue
+++ b/stubs/inertia-vue/resources/js/Components/Dropdown.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import { onMounted, onUnmounted, ref } from "vue";
+import { onMounted, onUnmounted, ref } from 'vue'
 
 export default {
     props: {

--- a/stubs/inertia-vue/resources/js/Components/ValidationErrors.vue
+++ b/stubs/inertia-vue/resources/js/Components/ValidationErrors.vue
@@ -16,7 +16,7 @@
             },
 
             hasErrors() {
-                return Object.keys(this.errors).length > 0;
+                return Object.keys(this.errors).length > 0
             },
         }
     }

--- a/stubs/inertia-vue/resources/js/Layouts/Authenticated.vue
+++ b/stubs/inertia-vue/resources/js/Layouts/Authenticated.vue
@@ -98,11 +98,11 @@
 </template>
 
 <script>
-    import BreezeApplicationLogo from '@/Components/ApplicationLogo'
-    import BreezeDropdown from '@/Components/Dropdown'
-    import BreezeDropdownLink from '@/Components/DropdownLink'
-    import BreezeNavLink from '@/Components/NavLink'
-    import BreezeResponsiveNavLink from '@/Components/ResponsiveNavLink'
+    import BreezeApplicationLogo from '@/Components/ApplicationLogo.vue'
+    import BreezeDropdown from '@/Components/Dropdown.vue'
+    import BreezeDropdownLink from '@/Components/DropdownLink.vue'
+    import BreezeNavLink from '@/Components/NavLink.vue'
+    import BreezeResponsiveNavLink from '@/Components/ResponsiveNavLink.vue'
 
     export default {
         components: {

--- a/stubs/inertia-vue/resources/js/Layouts/Guest.vue
+++ b/stubs/inertia-vue/resources/js/Layouts/Guest.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-    import BreezeApplicationLogo from '@/Components/ApplicationLogo'
+    import BreezeApplicationLogo from '@/Components/ApplicationLogo.vue'
 
     export default {
         components: {

--- a/stubs/inertia-vue/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -20,11 +20,11 @@
 </template>
 
 <script>
-    import BreezeButton from '@/Components/Button'
-    import BreezeGuestLayout from "@/Layouts/Guest"
-    import BreezeInput from '@/Components/Input'
-    import BreezeLabel from '@/Components/Label'
-    import BreezeValidationErrors from '@/Components/ValidationErrors'
+    import BreezeButton from '@/Components/Button.vue'
+    import BreezeGuestLayout from '@/Layouts/Guest.vue'
+    import BreezeInput from '@/Components/Input.vue'
+    import BreezeLabel from '@/Components/Label.vue'
+    import BreezeValidationErrors from '@/Components/ValidationErrors.vue'
 
     export default {
         layout: BreezeGuestLayout,

--- a/stubs/inertia-vue/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/ForgotPassword.vue
@@ -24,11 +24,11 @@
 </template>
 
 <script>
-    import BreezeButton from '@/Components/Button'
-    import BreezeGuestLayout from "@/Layouts/Guest"
-    import BreezeInput from '@/Components/Input'
-    import BreezeLabel from '@/Components/Label'
-    import BreezeValidationErrors from '@/Components/ValidationErrors'
+    import BreezeButton from '@/Components/Button.vue'
+    import BreezeGuestLayout from '@/Layouts/Guest.vue'
+    import BreezeInput from '@/Components/Input.vue'
+    import BreezeLabel from '@/Components/Label.vue'
+    import BreezeValidationErrors from '@/Components/ValidationErrors.vue'
 
     export default {
         layout: BreezeGuestLayout,

--- a/stubs/inertia-vue/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/Login.vue
@@ -36,12 +36,12 @@
 </template>
 
 <script>
-    import BreezeButton from '@/Components/Button'
-    import BreezeGuestLayout from "@/Layouts/Guest"
-    import BreezeInput from '@/Components/Input'
-    import BreezeCheckbox from '@/Components/Checkbox'
-    import BreezeLabel from '@/Components/Label'
-    import BreezeValidationErrors from '@/Components/ValidationErrors'
+    import BreezeButton from '@/Components/Button.vue'
+    import BreezeGuestLayout from '@/Layouts/Guest.vue'
+    import BreezeInput from '@/Components/Input.vue'
+    import BreezeCheckbox from '@/Components/Checkbox.vue'
+    import BreezeLabel from '@/Components/Label.vue'
+    import BreezeValidationErrors from '@/Components/ValidationErrors.vue'
 
     export default {
         layout: BreezeGuestLayout,

--- a/stubs/inertia-vue/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/Register.vue
@@ -35,11 +35,11 @@
 </template>
 
 <script>
-    import BreezeButton from '@/Components/Button'
-    import BreezeGuestLayout from '@/Layouts/Guest'
-    import BreezeInput from '@/Components/Input'
-    import BreezeLabel from '@/Components/Label'
-    import BreezeValidationErrors from '@/Components/ValidationErrors'
+    import BreezeButton from '@/Components/Button.vue'
+    import BreezeGuestLayout from '@/Layouts/Guest.vue'
+    import BreezeInput from '@/Components/Input.vue'
+    import BreezeLabel from '@/Components/Label.vue'
+    import BreezeValidationErrors from '@/Components/ValidationErrors.vue'
 
     export default {
         layout: BreezeGuestLayout,

--- a/stubs/inertia-vue/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/ResetPassword.vue
@@ -26,11 +26,11 @@
 </template>
 
 <script>
-    import BreezeButton from '@/Components/Button'
-    import BreezeGuestLayout from "@/Layouts/Guest"
-    import BreezeInput from '@/Components/Input'
-    import BreezeLabel from '@/Components/Label'
-    import BreezeValidationErrors from '@/Components/ValidationErrors'
+    import BreezeButton from '@/Components/Button.vue'
+    import BreezeGuestLayout from '@/Layouts/Guest.vue'
+    import BreezeInput from '@/Components/Input.vue'
+    import BreezeLabel from '@/Components/Label.vue'
+    import BreezeValidationErrors from '@/Components/ValidationErrors.vue'
 
     export default {
         layout: BreezeGuestLayout,

--- a/stubs/inertia-vue/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/VerifyEmail.vue
@@ -19,8 +19,8 @@
 </template>
 
 <script>
-    import BreezeButton from '@/Components/Button'
-    import BreezeGuestLayout from "@/Layouts/Guest"
+    import BreezeButton from '@/Components/Button.vue'
+    import BreezeGuestLayout from '@/Layouts/Guest.vue'
 
     export default {
         layout: BreezeGuestLayout,

--- a/stubs/inertia-vue/resources/js/Pages/Dashboard.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Dashboard.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-    import BreezeAuthenticatedLayout from '@/Layouts/Authenticated'
+    import BreezeAuthenticatedLayout from '@/Layouts/Authenticated.vue'
 
     export default {
         components: {

--- a/stubs/inertia-vue/resources/js/app.js
+++ b/stubs/inertia-vue/resources/js/app.js
@@ -8,7 +8,7 @@ import { InertiaProgress } from '@inertiajs/progress';
 const el = document.getElementById('app');
 
 createInertiaApp({
-    resolve: (name) => require(`./Pages/${name}`),
+    resolve: (name) => require(`./Pages/${name}.vue`),
     setup({ el, app, props, plugin }) {
         createApp({ render: () => h(app, props) })
             .mixin({ methods: { route } })


### PR DESCRIPTION
This PR adds the `.vue` extension to all Breeze Vue imports.

This will become useful when someone want to switch from Laravel Mix to ViteJS because Vite does not support extension-less Vue imports. You can take a look here (https://github.com/vitejs/vite/issues/178#issuecomment-630138450)