### PR TITLE
Add missing href

### DIFF
--- a/stubs/inertia-vue/resources/js/Components/DropdownLink.vue
+++ b/stubs/inertia-vue/resources/js/Components/DropdownLink.vue
@@ -1,5 +1,5 @@
 <template>
-    <Link class="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out">
+    <Link :href="href" class="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out">
         <slot />
     </Link>
 </template>
@@ -10,6 +10,8 @@ import { Link } from '@inertiajs/inertia-vue3';
 export default {
     components: {
         Link,
-    }
+    },
+    
+    props: ['href'],
 }
 </script>


### PR DESCRIPTION
Getting `Cannot read property 'toString' of undefined` error on VueJS installations. This will add the needed `href` attribute.

Tested on Laravel v8.51 and PHP 8.0.7.

UPDATE: Just tested again on branch `1.x` and it is working correctly on a fresh install. Unsure why I was getting errors at first with the `BreezeDropdownLink`.

You can decline PR or add it in, whatever you feel is best for the project.