### PR TITLE
Fix - Change from POST to GET on responsive dashboard link

### DIFF
--- a/stubs/inertia-react/resources/js/Layouts/Authenticated.js
+++ b/stubs/inertia-react/resources/js/Layouts/Authenticated.js
@@ -92,7 +92,6 @@ export default function Authenticated({ auth, header, children }) {
                 <div className={(showingNavigationDropdown ? 'block' : 'hidden') + ' sm:hidden'}>
                     <div className="pt-2 pb-3 space-y-1">
                         <ResponsiveNavLink
-                            method="post"
                             href={route('dashboard')}
                             active={route().current('dashboard')}
                         >

--- a/stubs/inertia-react/resources/js/Layouts/Authenticated.js
+++ b/stubs/inertia-react/resources/js/Layouts/Authenticated.js
@@ -91,10 +91,7 @@ export default function Authenticated({ auth, header, children }) {
 
                 <div className={(showingNavigationDropdown ? 'block' : 'hidden') + ' sm:hidden'}>
                     <div className="pt-2 pb-3 space-y-1">
-                        <ResponsiveNavLink
-                            href={route('dashboard')}
-                            active={route().current('dashboard')}
-                        >
+                        <ResponsiveNavLink href={route('dashboard')} active={route().current('dashboard')}>
                             Dashboard
                         </ResponsiveNavLink>
                     </div>


### PR DESCRIPTION
The responsive (mobile) link to the Dashboard, has the wrong method applied to the link, to a route that does not exist by default (POST on /dashboard). This PR simply changes the link to be in line with the one show on the desktop version.
