### PR TITLE
Fix React Dropdown.js Link

### DIFF
--- a/stubs/inertia-react/resources/js/Components/Dropdown.js
+++ b/stubs/inertia-react/resources/js/Components/Dropdown.js
@@ -73,7 +73,7 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
     );
 };
 
-const Link = ({ href, method = 'post', as = 'a', children }) => {
+const DropdownLink = ({ href, method = 'post', as = 'a', children }) => {
     return (
         <Link
             href={href}
@@ -88,6 +88,6 @@ const Link = ({ href, method = 'post', as = 'a', children }) => {
 
 Dropdown.Trigger = Trigger;
 Dropdown.Content = Content;
-Dropdown.Link = Link;
+Dropdown.Link = DropdownLink;
 
 export default Dropdown;


### PR DESCRIPTION
The previous commit fixed `InertiaLink` to `Link` which now created an error when running `npm run dev`. This commit fixes "Identifier 'Link' has already been declared" error. 