### PR TITLE
[1.x] Replace docs with link to actual docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,9 @@ Breeze provides a minimal and simple starting point for building a Laravel appli
 
 Laravel Breeze is powered by Blade and Tailwind. If you're looking for a more robust Laravel starter kit that includes two factor authentication, Livewire / Inertia support, and more, check out [Laravel Jetstream](https://jetstream.laravel.com).
 
-Getting started couldn't be easier:
+## Official Documentation
 
-```bash
-laravel new my-app
-
-cd my-app
-
-composer require laravel/breeze --dev
-
-php artisan breeze:install
-```
+Documentation for Breeze can be found on the [Laravel website](https://laravel.com/docs/8.x/starter-kits#laravel-breeze).
 
 ## Contributing
 


### PR DESCRIPTION
Seems like Breeze is one of the only packages that doesn't yet have the same link as the rest of our packages.