### PR TITLE
Use passwordConfirmed() method

### DIFF
--- a/stubs/default/App/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/default/App/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -37,7 +37,7 @@ class ConfirmablePasswordController extends Controller
             ]);
         }
 
-        $request->session()->put('auth.password_confirmed_at', time());
+        $request->session()->passwordConfirmed();
 
         return redirect()->intended(RouteServiceProvider::HOME);
     }


### PR DESCRIPTION
Seems about right to use the framework method instead of duplicating that code block?

See commit https://github.com/laravel/framework/commit/fb3f45aa0142764c5c29b97e8bcf8328091986e9
