### PR TITLE
upgrade alpinejs to v3

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,7 +45,7 @@ class InstallCommand extends Command
         $this->updateNodePackages(function ($packages) {
             return [
                 '@tailwindcss/forms' => '^0.2.1',
-                'alpinejs' => '^2.7.3',
+                'alpinejs' => '^3.4.2',
                 'autoprefixer' => '^10.1.0',
                 'postcss' => '^8.2.1',
                 'postcss-import' => '^12.0.1',

--- a/stubs/default/resources/js/app.js
+++ b/stubs/default/resources/js/app.js
@@ -1,3 +1,7 @@
 require('./bootstrap');
 
-require('alpinejs');
+import Alpine from 'alpinejs'
+ 
+window.Alpine = Alpine
+ 
+Alpine.start()

--- a/stubs/default/resources/js/app.js
+++ b/stubs/default/resources/js/app.js
@@ -1,7 +1,7 @@
 require('./bootstrap');
 
-import Alpine from 'alpinejs'
+import Alpine from 'alpinejs';
  
-window.Alpine = Alpine
+window.Alpine = Alpine;
  
-Alpine.start()
+Alpine.start();

--- a/stubs/default/resources/views/components/dropdown.blade.php
+++ b/stubs/default/resources/views/components/dropdown.blade.php
@@ -21,7 +21,7 @@ switch ($width) {
 }
 @endphp
 
-<div class="relative" x-data="{ open: false }" @click.away="open = false" @close.stop="open = false">
+<div class="relative" x-data="{ open: false }" @click.outside="open = false" @close.stop="open = false">
     <div @click="open = ! open">
         {{ $trigger }}
     </div>


### PR DESCRIPTION
Upgrade alpinejs version from v2 to v3
Change app.js to call alpinejs, source [https://alpinejs.dev/essentials/installation#as-a-module](https://alpinejs.dev/essentials/installation#as-a-module)
Rename `@click.away` to `@click.outside`, source [https://alpinejs.dev/upgrade-guide#away-replace-with-outside](https://alpinejs.dev/upgrade-guide#away-replace-with-outside)