### PR TITLE
Add orchestra/testbench as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "orchestra/testbench": "^6.23"
+    }
 }


### PR DESCRIPTION
This PR adds `orchestra/testbench` package as a dev dependency to allow for IDEs to have access to Laravel's class/functions declarations.