### PR TITLE
Fix Inertia Controllers @return tag and Inertia Vue Input Component

### DIFF
--- a/stubs/inertia-common/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -14,7 +14,7 @@ class ConfirmablePasswordController extends Controller
     /**
      * Show the confirm password view.
      *
-     * @return \Illuminate\View\View
+     * @return \Inertia\Response
      */
     public function show()
     {

--- a/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -12,7 +12,7 @@ class EmailVerificationNotificationController extends Controller
      * Send a new email verification notification.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(Request $request)
     {

--- a/stubs/inertia-common/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/NewPasswordController.php
@@ -18,7 +18,7 @@ class NewPasswordController extends Controller
      * Display the password reset view.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\View\View
+     * @return \Inertia\Response
      */
     public function create(Request $request)
     {

--- a/stubs/inertia-common/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -13,7 +13,7 @@ class PasswordResetLinkController extends Controller
     /**
      * Display the password reset link request view.
      *
-     * @return \Illuminate\View\View
+     * @return \Inertia\Response
      */
     public function create()
     {

--- a/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -17,7 +17,7 @@ class RegisteredUserController extends Controller
     /**
      * Display the registration view.
      *
-     * @return \Illuminate\View\View
+     * @return \Inertia\Response
      */
     public function create()
     {

--- a/stubs/inertia-vue/resources/js/Components/Input.vue
+++ b/stubs/inertia-vue/resources/js/Components/Input.vue
@@ -12,6 +12,6 @@ export default {
         focus() {
             this.$refs.input.focus()
         }
-    },
+    }
 }
 </script>

--- a/stubs/inertia-vue/resources/js/Components/Input.vue
+++ b/stubs/inertia-vue/resources/js/Components/Input.vue
@@ -12,6 +12,12 @@ export default {
         focus() {
             this.$refs.input.focus()
         }
+    },
+
+    mounted() {
+        if (this.$refs.input.hasAttribute('autofocus')) {
+            this.focus()
+        }
     }
 }
 </script>

--- a/stubs/inertia-vue/resources/js/Components/Input.vue
+++ b/stubs/inertia-vue/resources/js/Components/Input.vue
@@ -13,11 +13,5 @@ export default {
             this.$refs.input.focus()
         }
     },
-
-    mounted() {
-        if (this.$refs.input.hasAttribute('autofocus')) {
-            this.focus()
-        }
-    }
 }
 </script>


### PR DESCRIPTION
- Fix correct @return tag for Inertia response

- Fix Inertia vue Input component autofocus. The method `focus()` doesn't work. With this change the method is called if input has attribute "autofocus" on mounted.