### PR TITLE
Auto update changelog on release

### DIFF
--- a/.github/workflows/update-changelog.md
+++ b/.github/workflows/update-changelog.md
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.ref_name }}
+          commit_message: Update CHANGELOG.md
+          file_pattern: CHANGELOG.md


### PR DESCRIPTION
Trying out the auto updater for a Changelog by @stefanzweifel on Breeze. If this goes well, I'll roll this out to every repo.

Could potentially save me quite a bit of time while doing release 🤞 