### PR TITLE
update outdated dependencies for react stack

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -90,15 +90,15 @@ trait InstallsInertiaStacks
     protected function installInertiaReactStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3.5', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.4.5', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0');
 
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@headlessui/react' => '^1.2.0',
-                '@inertiajs/inertia' => '^0.9.0',
-                '@inertiajs/inertia-react' => '^0.6.0',
-                '@inertiajs/progress' => '^0.2.4',
+                '@headlessui/react' => '^1.4.2',
+                '@inertiajs/inertia' => '^0.10.0',
+                '@inertiajs/inertia-react' => '^0.7.0',
+                '@inertiajs/progress' => '^0.2.6',
                 '@tailwindcss/forms' => '^0.4.0',
                 'autoprefixer' => '^10.2.4',
                 'postcss' => '^8.2.13',
@@ -106,7 +106,7 @@ trait InstallsInertiaStacks
                 'tailwindcss' => '^3.0.0',
                 'react' => '^17.0.2',
                 'react-dom' => '^17.0.2',
-                '@babel/preset-react' => '^7.13.13',
+                '@babel/preset-react' => '^7.16.7',
             ] + $packages;
         });
 


### PR DESCRIPTION
I noticed there was a couple of things not working, and then i realized it was an outdated dependencies issue. Turns out a lot of the dependencies for React Stack was outdated, which is funny because the same doesn't occur for the Vue one. I don't really like vue myself so i stick to react.