### PR TITLE
Remove brackets on react label component

### DIFF
--- a/stubs/inertia-react/resources/js/Components/Label.js
+++ b/stubs/inertia-react/resources/js/Components/Label.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default function Label({ forInput, value, className, children }) {
     return (
         <label htmlFor={forInput} className={`block font-medium text-sm text-gray-700 ` + className}>
-            {value ? value : { children }}
+            {value ? value : children}
         </label>
     );
 }


### PR DESCRIPTION
```js
<Label htmlFor="current_password">
    Current Password
</Label>
```
And you'll get an error like so `Uncaught Error: Objects are not valid as a React child (found: object with keys {children})`

But if you remove the brackets before the children, it'll gone.

```js
// Before
{value ? value : { children }}

// After
{value ? value : children}
```
Now, we can use `Label` either with `children` or `forInput` props. 