### PR TITLE
Fix API Controllers @return tag

### DIFF
--- a/stubs/api/App/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/api/App/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -12,7 +12,7 @@ class EmailVerificationNotificationController extends Controller
      * Send a new email verification notification.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     public function store(Request $request)
     {

--- a/stubs/api/App/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/api/App/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -12,7 +12,7 @@ class EmailVerificationNotificationController extends Controller
      * Send a new email verification notification.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
     public function store(Request $request)
     {

--- a/stubs/api/App/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/api/App/Http/Controllers/Auth/NewPasswordController.php
@@ -17,7 +17,7 @@ class NewPasswordController extends Controller
      * Handle an incoming new password request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\JsonResponse
      *
      * @throws \Illuminate\Validation\ValidationException
      */

--- a/stubs/api/App/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/api/App/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -13,7 +13,7 @@ class PasswordResetLinkController extends Controller
      * Handle an incoming password reset link request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\JsonResponse
      *
      * @throws \Illuminate\Validation\ValidationException
      */

--- a/stubs/api/App/Http/Middleware/EnsureEmailIsVerified.php
+++ b/stubs/api/App/Http/Middleware/EnsureEmailIsVerified.php
@@ -13,7 +13,7 @@ class EnsureEmailIsVerified
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  $redirectToRoute
-     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|null
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse|null
      */
     public function handle($request, Closure $next, $redirectToRoute = null)
     {


### PR DESCRIPTION
This pull request fixes the DocBlocks `@return` tag for API scaffolding

- Use `JsonResponse` instated of `RedirectResponse`
