### PR TITLE
Use FRONTEND_URL port in Sanctum config

### DIFF
--- a/stubs/api/config/sanctum.php
+++ b/stubs/api/config/sanctum.php
@@ -20,7 +20,7 @@ return [
         env('FRONTEND_URL')
             ? ','.implode(':', \Illuminate\Support\Arr::whereNotNull([
                 parse_url(env('FRONTEND_URL'), PHP_URL_HOST),
-                parse_url(env('FRONTEND_URL'), PHP_URL_PORT)
+                parse_url(env('FRONTEND_URL'), PHP_URL_PORT),
             ]))
             : ''
     ))),

--- a/stubs/api/config/sanctum.php
+++ b/stubs/api/config/sanctum.php
@@ -17,7 +17,12 @@ return [
         '%s%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : '',
-        env('FRONTEND_URL') ? ','.parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : ''
+        env('FRONTEND_URL')
+            ? ','.implode(':', \Illuminate\Support\Arr::whereNotNull([
+                parse_url(env('FRONTEND_URL'), PHP_URL_HOST),
+                parse_url(env('FRONTEND_URL'), PHP_URL_PORT)
+            ]))
+            : ''
     ))),
 
     /*


### PR DESCRIPTION
If `FRONTEND_URL` has some other port in local development than default `:3000` it is dropped out in `sanctum.php` and cookies do not work. 

Other option would be change the [documentation](https://laravel.com/docs/8.x/starter-kits#breeze-and-next) to have a notice of including the host in SANCTUM_STATEFUL_DOMAINS.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
