### PR TITLE
[1.x] Fix exception throwing on older PHP versions

### DIFF
--- a/stubs/api/App/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/api/App/Http/Controllers/Auth/NewPasswordController.php
@@ -44,10 +44,12 @@ class NewPasswordController extends Controller
             }
         );
 
-        return $status == Password::PASSWORD_RESET
-                ? response()->json(['status' => __($status)])
-                : throw ValidationException::withMessages([
-                    'email' => [__($status)],
-                ]);
+        if ($status != Password::PASSWORD_RESET) {
+            throw ValidationException::withMessages([
+                'email' => [__($status)],
+            ]);
+        }
+
+        return response()->json(['status' => __($status)]);
     }
 }

--- a/stubs/api/App/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/api/App/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -30,10 +30,12 @@ class PasswordResetLinkController extends Controller
             $request->only('email')
         );
 
-        return $status == Password::RESET_LINK_SENT
-                    ? response()->json(['status' => __($status)])
-                    : throw ValidationException::withMessages([
-                        'email' => [__($status)],
-                    ]);
+        if ($status != Password::RESET_LINK_SENT) {
+            throw ValidationException::withMessages([
+                'email' => [__($status)],
+            ]);
+        }
+
+        return response()->json(['status' => __($status)]);
     }
 }


### PR DESCRIPTION
#109 introduced some exception throwing with ternary expressions. However, this is only available as of PHP 8 and Breeze still supports PHP 7.3 and 7.4.
