### PR TITLE
[1.x] Push updated Changelog to default branch

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: ${{ github.ref_name }}
+          branch: ${{ github.event.repository.default_branch }}
           commit_message: Update CHANGELOG.md
           file_pattern: CHANGELOG.md

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: ${{ github.event.repository.default_branch }}
+          branch: ${{ github.event.release.target_commitish }}
           commit_message: Update CHANGELOG.md
           file_pattern: CHANGELOG.md


### PR DESCRIPTION
This PR fixes the `update-changelog.yml` workflow to push the changed workflow to the repositories default branch.

Previously the workflow used `${{ github.ref_name }}` which evaluates to the tag name (`v1.0.0`). This doesn't work as `v1.0.0` is not an actual branch in the repository.
We are now using `${{ github.event.repository.default_branch }}` which evaluates to `1.x`. 

This should resolve the issue Dires mentioned in https://github.com/laravel/breeze/pull/113#issuecomment-1021539840.
I've successfully tested this in a test repository:

- [Workflow File](https://github.com/stefanzweifel/git-auto-commit-action-non-default-branch/actions/runs/1749707173/workflow)
- [Workflow run](https://github.com/stefanzweifel/git-auto-commit-action-non-default-branch/runs/4948435325?check_suite_focus=true#step:5:17
)

Technically we could already use `github.event.repository.default_branch` in the checkout process, but this works fine too.