### PR TITLE
FIX: Api stack EmailVerificationTest assertRedirect

### DIFF
--- a/stubs/api/tests/Feature/EmailVerificationTest.php
+++ b/stubs/api/tests/Feature/EmailVerificationTest.php
@@ -32,7 +32,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
+        $response->assertRedirect(config('app.frontend_url').RouteServiceProvider::HOME.'?verified=1');
     }
 
     public function test_email_is_not_verified_with_invalid_hash()


### PR DESCRIPTION
fixed the EmailVerificationTest.php

```diff
-$response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
+$response->assertRedirect(config('app.frontend_url').RouteServiceProvider::HOME.'?verified=1');
```
