### PR TITLE
Don't mix __() and trans() in the same file

### DIFF
--- a/stubs/default/App/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/default/App/Http/Requests/Auth/LoginRequest.php
@@ -49,7 +49,7 @@ class LoginRequest extends FormRequest
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
-                'email' => __('auth.failed'),
+                'email' => trans('auth.failed'),
             ]);
         }
 


### PR DESCRIPTION
Currently we're using both the `trans` and the `__` helper functions.
Makes sense to just use one.

(I personally use `trans` over `__` due to the existence of `trans_choice` but this PR could be closed and `__` used instead if you'd prefer).