### PR TITLE
[1.x] Fix assertRedirect in EmailVerificationTest when using API with pest

### DIFF
--- a/stubs/api/pest-tests/Feature/EmailVerificationTest.php
+++ b/stubs/api/pest-tests/Feature/EmailVerificationTest.php
@@ -23,7 +23,7 @@ test('email can be verified', function () {
 
     Event::assertDispatched(Verified::class);
     expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
-    $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
+    $response->assertRedirect(config('app.frontend_url').RouteServiceProvider::HOME.'?verified=1');
 });
 
 test('email is not verified with invalid hash', function () {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes the asserted redirect route in the `EmailVerificationTest` of the `api` stack when using the `--pest` test suite.

This is basically the same like #122 updated for the default phpunit tests.
