### PR TITLE
[1.x] add routes name to register and login  paths

### DIFF
--- a/stubs/api/routes/auth.php
+++ b/stubs/api/routes/auth.php
@@ -9,10 +9,12 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/register', [RegisteredUserController::class, 'store'])
-                ->middleware('guest');
+                ->middleware('guest')
+                ->name('register');
 
 Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-                ->middleware('guest');
+                ->middleware('guest')
+                ->name('login');
 
 Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
                 ->middleware('guest')


### PR DESCRIPTION
### Versions

- PHP 8.1.2
- Laravel 9.1.0


file: `app/Http/Middleware/Authenticate.php` uses route helper with name `login`
This PR adds the route name `login`
 
```php
<?php
namespace App\Http\Middleware;
use Illuminate\Auth\Middleware\Authenticate as Middleware;

class Authenticate extends Middleware {
    /**
     * Get the path the user should be redirected to when they are not authenticated.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return string|null
     */
    protected function redirectTo($request)
    {
        if (! $request->expectsJson()) {
            return route('login');
        }
    }
}
```

## Reproducing

```sh
laravel new laravel-api
cd laravel-api
php artisan breeze:install api
# setup db
php artisan migrate
php artisan serve
# visit http://localhost:8000/api/user
# see error Symfony\Component\Routing\Exception\RouteNotFoundException
```