### PR TITLE
Updated Inertia Version to Latest

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -19,7 +19,7 @@ trait InstallsInertiaStacks
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@inertiajs/inertia' => '^0.10.0',
+                '@inertiajs/inertia' => '^0.11.0',
                 '@inertiajs/inertia-vue3' => '^0.6.0',
                 '@inertiajs/progress' => '^0.2.6',
                 '@tailwindcss/forms' => '^0.4.0',


### PR DESCRIPTION
## Issue

I tried to install Laravel breeze with Inertia following [Docs](https://laravel.com/docs/9.x/starter-kits#breeze-and-inertia) but I got following error while installing node packages:

![Screenshot from 2022-02-21 22-00-35](https://user-images.githubusercontent.com/32318794/155000823-4ce8f78e-7fe0-44ad-afd5-8a7af8ad73f3.png)

## Fix
I updated inertia version to latest (0.11.0) as mentioned in [Inertia Releases](https://github.com/inertiajs/inertia/releases) 

After this update, everything worked fine.

## Note
I only work with Vue, So I did not updated this version for react because  it may be working fine.
