### PR TITLE
update cors.php

### DIFF
--- a/stubs/api/config/cors.php
+++ b/stubs/api/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => [env('FRONTEND_URL')],
+    'allowed_origins' => [env('FRONTEND_URL', 'http://localhost:3000')],
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
Hi,

This is the first time I make a pull request. Please let me know If I miss something. Thanks

About the issue

I deploy the app (Octane) with the api option to the forge. Somehow the env is not add the **FRONTEND_URL** in to the ```.env``` file by default. The 500 happen. After I check I realize I missing the **FRONTEND_URL** in the ```.env``` file.

Double check the source code and I saw the ```cors.php``` config file missing the default value.

So, I make a patch. Please help me review. Thanks again 😇

Have a nice day. 🥳