### PR TITLE
Lovecoding git issue fix

### DIFF
--- a/stubs/inertia-react/resources/js/Components/Dropdown.js
+++ b/stubs/inertia-react/resources/js/Components/Dropdown.js
@@ -25,7 +25,7 @@ const Trigger = ({ children }) => {
         <>
             <div onClick={toggleOpen}>{children}</div>
 
-            {open && <div className="fixed inset-0 z-40" onClick={() => setOpen(false)}></div>}
+            {open && <div className="fixed inset-0" onClick={() => setOpen(false)}></div>}
         </>
     );
 };

--- a/stubs/inertia-vue/resources/js/Components/Dropdown.vue
+++ b/stubs/inertia-vue/resources/js/Components/Dropdown.vue
@@ -48,7 +48,7 @@ const open = ref(false);
         </div>
 
         <!-- Full Screen Dropdown Overlay -->
-        <div v-show="open" class="fixed inset-0 z-40" @click="open = false"></div>
+        <div v-show="open" class="fixed inset-0" @click="open = false"></div>
 
         <transition
             enter-active-class="transition ease-out duration-200"


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I installed the fresh Laravel V9 and Breeze react.
When I login and click dropdown, I can't click Log Out since it has `z-40` and when I remove that class, it works.

I think we can either remove `z-40` class or add some `relative z-50` to dropdown transform.

![image](https://user-images.githubusercontent.com/61916777/165982642-6a9a829b-c6d2-4bd8-991c-82a023ab4914.png)
