### PR TITLE
[1.x] Fix inability to click dropdown content in React version

### DIFF
--- a/stubs/inertia-react/resources/js/Components/Dropdown.js
+++ b/stubs/inertia-react/resources/js/Components/Dropdown.js
@@ -63,9 +63,7 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
                     className={`absolute z-50 mt-2 rounded-md shadow-lg ${alignmentClasses} ${widthClasses}`}
                     onClick={() => setOpen(false)}
                 >
-                    <div className={`rounded-md ring-1 ring-black ring-opacity-5 ` + contentClasses}>
-                        {children}
-                    </div>
+                    <div className={`rounded-md ring-1 ring-black ring-opacity-5 ` + contentClasses}>{children}</div>
                 </div>
             </Transition>
         </>

--- a/stubs/inertia-react/resources/js/Components/Dropdown.js
+++ b/stubs/inertia-react/resources/js/Components/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, Fragment } from 'react';
 import { Link } from '@inertiajs/inertia-react';
 import { Transition } from '@headlessui/react';
 
@@ -50,6 +50,7 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
     return (
         <>
             <Transition
+                as={Fragment}
                 show={open}
                 enter="transition ease-out duration-200"
                 enterFrom="transform opacity-0 scale-95"
@@ -58,16 +59,14 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
             >
-                {open && (
-                    <div
-                        className={`absolute z-50 mt-2 rounded-md shadow-lg ${alignmentClasses} ${widthClasses}`}
-                        onClick={() => setOpen(false)}
-                    >
-                        <div className={`rounded-md ring-1 ring-black ring-opacity-5 ` + contentClasses}>
-                            {children}
-                        </div>
+                <div
+                    className={`absolute z-50 mt-2 rounded-md shadow-lg ${alignmentClasses} ${widthClasses}`}
+                    onClick={() => setOpen(false)}
+                >
+                    <div className={`rounded-md ring-1 ring-black ring-opacity-5 ` + contentClasses}>
+                        {children}
                     </div>
-                )}
+                </div>
             </Transition>
         </>
     );


### PR DESCRIPTION
This PR fixes an issue where the content inside a dropdown (e.g. the "Log Out" link) was unable to be clicked in the React version of Breeze.

The "click away" element (used to trigger the closing of the dropdown when clicking away from it) was covering the dropdown menu, so when you think you are clicking the dropdown, you are actually hitting the click-away element, even though the dropdown has a higher z-index.

This is because the Headless UI `Transition` component creates a wrapper div by default. The wrapper div has `transform` and `opacity` properties which create a new z-index [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).

```html
<!-- click away element -->
<div class="fixed inset-0 z-40"></div>

<!-- transition wrapper -->
<div class="transform opacity-100 scale-100">   <-- creates a new stacking context
    <div class="absolute z-50">
        <!-- dropdown content -->
    </div>
</div>
```

A solution is to tell the `Transition` component to render as a [`Fragment`](https://reactjs.org/docs/fragments.html) which does not render an additional DOM node:

```html
<!-- click away element -->
<div class="fixed inset-0 z-40"></div>

<!-- transition classes are applied directly to the menu -->
<div class="transform opacity-100 scale-100 absolute z-50">
    <!-- dropdown content -->
</div>
```

This is also how Vue's `<transition>` component works by default.

I also removed the additional "open" logic because the fragment requires a child node to exist unconditionally, and the `show` attribute on the `<Transition>` element already controls the visibility.