### PR TITLE
bump TailwindCSS to 3.1

### DIFF
--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -20,7 +20,7 @@ trait InstallsBladeStack
                 'alpinejs' => '^3.4.2',
                 'autoprefixer' => '^10.4.2',
                 'postcss' => '^8.4.6',
-                'tailwindcss' => '^3.0.18',
+                'tailwindcss' => '^3.1.0',
             ] + $packages;
         });
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -27,7 +27,7 @@ trait InstallsInertiaStacks
                 '@vue/compiler-sfc' => '^3.2.31',
                 'autoprefixer' => '^10.4.2',
                 'postcss' => '^8.4.6',
-                'tailwindcss' => '^3.0.18',
+                'tailwindcss' => '^3.1.0',
                 'vue' => '^3.2.31',
                 'vue-loader' => '^17.0.0',
             ] + $packages;
@@ -133,7 +133,7 @@ trait InstallsInertiaStacks
                 '@tailwindcss/forms' => '^0.4.0',
                 'autoprefixer' => '^10.4.2',
                 'postcss' => '^8.4.6',
-                'tailwindcss' => '^3.0.18',
+                'tailwindcss' => '^3.1.0',
                 'react' => '^17.0.2',
                 'react-dom' => '^17.0.2',
                 '@babel/preset-react' => '^7.16.7',

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {

--- a/stubs/inertia-common/tailwind.config.js
+++ b/stubs/inertia-common/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {


### PR DESCRIPTION
Hey Laravel Team,

this PR updates TailwindCSS to the new 3.1 release and adds the new FirstParty TypeScript types to the tailwind.config.js.

https://tailwindcss.com/blog/tailwindcss-v3-1