### PR TITLE
Allow support for non-jsx React files in Tailwind config

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -187,7 +187,7 @@ trait InstallsInertiaStacks
 
         $this->replaceInFile('.vue()', '.react()', base_path('webpack.mix.js'));
         $this->replaceInFile('app.js', 'app.jsx', base_path('webpack.mix.js'));
-        $this->replaceInFile('.vue', '.jsx', base_path('tailwind.config.js'));
+        $this->replaceInFile('.vue', '.{jsx,js}', base_path('tailwind.config.js'));
 
         if ($this->option('ssr')) {
             $this->installInertiaReactSsrStack();


### PR DESCRIPTION
Not all developers will use .jsx as the file extension for their React components. I was editing a React component recently with a .js prefix and realised my tailwind classes weren't getting generated correctly. This should help support that.