### PR TITLE
Sanctum configuration for current application URL from the APP_URL with Port

### DIFF
--- a/stubs/api/config/sanctum.php
+++ b/stubs/api/config/sanctum.php
@@ -1,7 +1,5 @@
 <?php
 
-use Laravel\Sanctum\Sanctum;
-
 return [
 
     /*
@@ -18,9 +16,9 @@ return [
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
-        env('APP_URL') ? ',' . parse_url(env('APP_URL'), PHP_URL_HOST) : '',
-        env('FRONTEND_URL') ? ',' . parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : '',
-        Sanctum::currentApplicationUrlWithPort()
+        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : '',
+        env('FRONTEND_URL') ? ','.parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : '',
+        \Laravel\Sanctum\Sanctum::currentApplicationUrlWithPort()
     ))),
 
     /*

--- a/stubs/api/config/sanctum.php
+++ b/stubs/api/config/sanctum.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Sanctum\Sanctum;
+
 return [
 
     /*
@@ -18,7 +20,7 @@ return [
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : '',
         env('FRONTEND_URL') ? ','.parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : '',
-        \Laravel\Sanctum\Sanctum::currentApplicationUrlWithPort()
+        Sanctum::currentApplicationUrlWithPort()
     ))),
 
     /*

--- a/stubs/api/config/sanctum.php
+++ b/stubs/api/config/sanctum.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Sanctum\Sanctum;
+
 return [
 
     /*
@@ -16,8 +18,9 @@ return [
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
-        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : '',
-        env('FRONTEND_URL') ? ','.parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : ''
+        env('APP_URL') ? ',' . parse_url(env('APP_URL'), PHP_URL_HOST) : '',
+        env('FRONTEND_URL') ? ',' . parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : '',
+        Sanctum::currentApplicationUrlWithPort()
     ))),
 
     /*


### PR DESCRIPTION
In `sanctum.php` config file, the Stateful domains can be added like this

```php
use Laravel\Sanctum\Sanctum;

'%s%s%s',
'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
env('APP_URL') ? ',' . parse_url(env('APP_URL'), PHP_URL_HOST) : '',
env('FRONTEND_URL') ? ',' . parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : '',
Sanctum::currentApplicationUrlWithPort() // newly added
```
![Screenshot_28](https://user-images.githubusercontent.com/17238742/176569281-5f5a37a4-2c28-4f76-abef-1690e50eae73.png)

