### PR TITLE
[1.x] Add default view / routes reloading to breeze stacks

### DIFF
--- a/stubs/default/vite.config.js
+++ b/stubs/default/vite.config.js
@@ -3,9 +3,12 @@ import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/css/app.css',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: [
+                'resources/css/app.css',
+                'resources/js/app.js',
+            ],
+            refresh: true,
+        }),
     ],
 });

--- a/stubs/inertia-react/vite.config.js
+++ b/stubs/inertia-react/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     plugins: [
         laravel({
             input: 'resources/js/app.jsx',
+            refresh: true,
         }),
         react(),
     ],

--- a/stubs/inertia-vue/vite.config.js
+++ b/stubs/inertia-vue/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     plugins: [
         laravel({
             input: 'resources/js/app.js',
+            refresh: true,
         }),
         vue({
             template: {


### PR DESCRIPTION
This PR makes all the breeze stacks come with the default Laravel watching configuration out of the box.

As it stands, this will perform a full page refresh while running `npm run dev` and saving files within the following directories:

```
resources/views/**
routes/**
```

The configured directories can still be manually configured if needed.

I believe this makes sense in all of these stacks as Inertia AND Ziggy are utilised, so this default refresh config should be a benefit to all the stacks.

Tested stacks:

- Blade
- Vue
- Vue --ssr
- React
- React --ssr

See: https://github.com/laravel/vite-plugin/pull/43