### PR TITLE
Laravel 8 don't support the vite.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/filesystem": "^8.42|^9.0",
-        "illuminate/support": "^8.42|^9.0",
-        "illuminate/validation": "^8.42|^9.0"
+        "php": "^8.0.2",
+        "illuminate/filesystem": "^9.0",
+        "illuminate/support": "^9.0",
+        "illuminate/validation": "^9.0"
     },
     "conflict": {
-        "laravel/framework": "< 9.0"
+        "laravel/framework": "<9.19.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "illuminate/support": "^8.42|^9.0",
         "illuminate/validation": "^8.42|^9.0"
     },
+    "conflict": {
+        "laravel/framework": "< 9.0"
+    },
     "autoload": {
         "psr-4": {
             "Laravel\\Breeze\\": "src/"


### PR DESCRIPTION
Actually, breeze v1.10.0 also needs this `conflict` rule.