### PR TITLE
Fix: React SSR installation error

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -185,7 +185,10 @@ trait InstallsInertiaStacks
         copy(__DIR__.'/../../stubs/inertia-common/jsconfig.json', base_path('jsconfig.json'));
         copy(__DIR__.'/../../stubs/inertia-react/vite.config.js', base_path('vite.config.js'));
         copy(__DIR__.'/../../stubs/inertia-react/resources/js/app.jsx', resource_path('js/app.jsx'));
-        unlink(resource_path('js/app.js'));
+        
+        if(file_exists(resource_path('js/app.js'))) {
+            unlink(resource_path('js/app.js'));
+        }
 
         $this->replaceInFile('.vue', '.jsx', base_path('tailwind.config.js'));
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -185,8 +185,8 @@ trait InstallsInertiaStacks
         copy(__DIR__.'/../../stubs/inertia-common/jsconfig.json', base_path('jsconfig.json'));
         copy(__DIR__.'/../../stubs/inertia-react/vite.config.js', base_path('vite.config.js'));
         copy(__DIR__.'/../../stubs/inertia-react/resources/js/app.jsx', resource_path('js/app.jsx'));
-        
-        if(file_exists(resource_path('js/app.js'))) {
+
+        if (file_exists(resource_path('js/app.js'))) {
             unlink(resource_path('js/app.js'));
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When I installed Breeze (React & SSR) as per this tutorial: https://laravel.com/docs/9.x/starter-kits#laravel-breeze-installation

When running the command `php artisan breeze:install react --ssr`, it returns an error like the following image.

This is because when we unlink the `app.js` file doesn't exist, I added checking for the existence of the file first.

![Screenshot 2022-07-11 144626](https://user-images.githubusercontent.com/49445216/178219175-09d1e0fd-92bd-44c8-ba2c-235bd2ec716e.png)

