### PR TITLE
Allow easy customization of accent color

### DIFF
--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -26,25 +26,22 @@
             <div class="mt-4">
                 <x-label for="password" :value="__('Password')" />
 
-                <x-input id="password" class="block mt-1 w-full"
-                                type="password"
-                                name="password"
-                                required autocomplete="current-password" />
+                <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="current-password" />
             </div>
 
             <!-- Remember Me -->
             <div class="block mt-4">
                 <label for="remember_me" class="inline-flex items-center">
-                    <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="remember">
+                    <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-brand-600 shadow-sm focus:border-brand-300 focus:ring focus:ring-brand-200 focus:ring-opacity-50" name="remember">
                     <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
                 </label>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 @if (Route::has('password.request'))
-                    <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
-                        {{ __('Forgot your password?') }}
-                    </a>
+                <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
+                    {{ __('Forgot your password?') }}
+                </a>
                 @endif
 
                 <x-button class="ml-3">

--- a/stubs/default/resources/views/components/input.blade.php
+++ b/stubs/default/resources/views/components/input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50']) !!}>
+<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'rounded-md shadow-sm border-gray-300 focus:border-brand-300 focus:ring focus:ring-brand-200 focus:ring-opacity-50']) !!}>

--- a/stubs/default/resources/views/components/nav-link.blade.php
+++ b/stubs/default/resources/views/components/nav-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
-            : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out';
+? 'inline-flex items-center px-1 pt-1 border-b-2 border-brand-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-brand-700 transition duration-150 ease-in-out'
+: 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out';
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/stubs/default/resources/views/components/responsive-nav-link.blade.php
+++ b/stubs/default/resources/views/components/responsive-nav-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'block pl-3 pr-4 py-2 border-l-4 border-indigo-400 text-base font-medium text-indigo-700 bg-indigo-50 focus:outline-none focus:text-indigo-800 focus:bg-indigo-100 focus:border-indigo-700 transition duration-150 ease-in-out'
-            : 'block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out';
+? 'block pl-3 pr-4 py-2 border-l-4 border-brand-400 text-base font-medium text-brand-700 bg-brand-50 focus:outline-none focus:text-brand-800 focus:bg-brand-100 focus:border-brand-700 transition duration-150 ease-in-out'
+: 'block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out';
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -1,4 +1,5 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
+const colors = require('tailwindcss/colors');
 
 module.exports = {
     content: [
@@ -12,6 +13,9 @@ module.exports = {
             fontFamily: {
                 sans: ['Nunito', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                brand: colors.indigo,
+            }
         },
     },
 

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
             },
             colors: {
                 brand: colors.indigo,
-            }
+            },
         },
     },
 

--- a/stubs/inertia-common/tailwind.config.js
+++ b/stubs/inertia-common/tailwind.config.js
@@ -1,4 +1,5 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
+const colors = require('tailwindcss/colors');
 
 module.exports = {
     content: [
@@ -13,6 +14,9 @@ module.exports = {
             fontFamily: {
                 sans: ['Nunito', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                brand: colors.indigo,
+            }
         },
     },
 

--- a/stubs/inertia-common/tailwind.config.js
+++ b/stubs/inertia-common/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
             },
             colors: {
                 brand: colors.indigo,
-            }
+            },
         },
     },
 

--- a/stubs/inertia-react/resources/js/Components/Checkbox.js
+++ b/stubs/inertia-react/resources/js/Components/Checkbox.js
@@ -6,7 +6,7 @@ export default function Checkbox({ name, value, handleChange }) {
             type="checkbox"
             name={name}
             value={value}
-            className="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+            className="rounded border-gray-300 text-brand-600 shadow-sm focus:border-brand-300 focus:ring focus:ring-brand-200 focus:ring-opacity-50"
             onChange={(e) => handleChange(e)}
         />
     );

--- a/stubs/inertia-react/resources/js/Components/Input.js
+++ b/stubs/inertia-react/resources/js/Components/Input.js
@@ -27,7 +27,7 @@ export default function Input({
                 id={id}
                 value={value}
                 className={
-                    `border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm ` +
+                    `border-gray-300 focus:border-brand-300 focus:ring focus:ring-brand-200 focus:ring-opacity-50 rounded-md shadow-sm ` +
                     className
                 }
                 ref={input}

--- a/stubs/inertia-react/resources/js/Components/NavLink.js
+++ b/stubs/inertia-react/resources/js/Components/NavLink.js
@@ -7,7 +7,7 @@ export default function NavLink({ href, active, children }) {
             href={href}
             className={
                 active
-                    ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
+                    ? 'inline-flex items-center px-1 pt-1 border-b-2 border-brand-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-brand-700 transition duration-150 ease-in-out'
                     : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out'
             }
         >

--- a/stubs/inertia-react/resources/js/Components/ResponsiveNavLink.js
+++ b/stubs/inertia-react/resources/js/Components/ResponsiveNavLink.js
@@ -9,7 +9,7 @@ export default function ResponsiveNavLink({ method = 'get', as = 'a', href, acti
             href={href}
             className={`w-full flex items-start pl-3 pr-4 py-2 border-l-4 ${
                 active
-                    ? 'border-indigo-400 text-indigo-700 bg-indigo-50 focus:outline-none focus:text-indigo-800 focus:bg-indigo-100 focus:border-indigo-700'
+                ? 'border-brand-400 text-brand-700 bg-brand-50 focus:outline-none focus:text-brand-800 focus:bg-brand-100 focus:border-brand-700'
                     : 'border-transparent text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300'
             } text-base font-medium focus:outline-none transition duration-150 ease-in-out`}
         >

--- a/stubs/inertia-react/resources/js/Components/ResponsiveNavLink.js
+++ b/stubs/inertia-react/resources/js/Components/ResponsiveNavLink.js
@@ -9,7 +9,7 @@ export default function ResponsiveNavLink({ method = 'get', as = 'a', href, acti
             href={href}
             className={`w-full flex items-start pl-3 pr-4 py-2 border-l-4 ${
                 active
-                ? 'border-brand-400 text-brand-700 bg-brand-50 focus:outline-none focus:text-brand-800 focus:bg-brand-100 focus:border-brand-700'
+                    ? 'border-brand-400 text-brand-700 bg-brand-50 focus:outline-none focus:text-brand-800 focus:bg-brand-100 focus:border-brand-700'
                     : 'border-transparent text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300'
             } text-base font-medium focus:outline-none transition duration-150 ease-in-out`}
         >

--- a/stubs/inertia-vue/resources/js/Components/Checkbox.vue
+++ b/stubs/inertia-vue/resources/js/Components/Checkbox.vue
@@ -1,6 +1,6 @@
 <template>
     <input type="checkbox" :value="value" v-model="proxyChecked"
-           class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+           class="rounded border-gray-300 text-brand-600 shadow-sm focus:border-brand-300 focus:ring focus:ring-brand-200 focus:ring-opacity-50">
 </template>
 
 <script>

--- a/stubs/inertia-vue/resources/js/Components/Input.vue
+++ b/stubs/inertia-vue/resources/js/Components/Input.vue
@@ -1,5 +1,5 @@
 <template>
-    <input class="border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" ref="input">
+    <input class="border-gray-300 focus:border-brand-300 focus:ring focus:ring-brand-200 focus:ring-opacity-50 rounded-md shadow-sm" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" ref="input">
 </template>
 
 <script>

--- a/stubs/inertia-vue/resources/js/Components/NavLink.vue
+++ b/stubs/inertia-vue/resources/js/Components/NavLink.vue
@@ -17,7 +17,7 @@ export default {
     computed: {
         classes() {
             return this.active
-                ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-indigo-700 transition  duration-150 ease-in-out'
+                ? 'inline-flex items-center px-1 pt-1 border-b-2 border-brand-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-brand-700 transition  duration-150 ease-in-out'
                 : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out'
         }
     }

--- a/stubs/inertia-vue/resources/js/Components/ResponsiveNavLink.vue
+++ b/stubs/inertia-vue/resources/js/Components/ResponsiveNavLink.vue
@@ -17,7 +17,7 @@ export default {
     computed: {
         classes() {
             return this.active
-                ? 'block pl-3 pr-4 py-2 border-l-4 border-indigo-400 text-base font-medium text-indigo-700 bg-indigo-50 focus:outline-none focus:text-indigo-800 focus:bg-indigo-100 focus:border-indigo-700 transition duration-150 ease-in-out'
+                ? 'block pl-3 pr-4 py-2 border-l-4 border-brand-400 text-base font-medium text-brand-700 bg-brand-50 focus:outline-none focus:text-brand-800 focus:bg-brand-100 focus:border-brand-700 transition duration-150 ease-in-out'
                 : 'block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out'
         }
     }


### PR DESCRIPTION
Often when creating new applications I like to use the boilerplate provided by breeze but often end up changing the accent color from the `indigo` default. This PR extends the Tailwind CSS config to include a `brand` color which is defaulted to `indigo`.

I targeted the `master` branch in case there would be breaking changes I didn't consider.

If approved to be merged I can also create a PR for documentation.

Examples below use the following config in the `tailwind.config.js` file:

Notice specifically the line `brand: colors.red,` instead of the new default of `brand:colors.indigo,`

```js
const defaultTheme = require('tailwindcss/defaultTheme');
const colors = require('tailwindcss/colors');

/** @type {import('tailwindcss').Config} */
module.exports = {
    content: [
        './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
        './storage/framework/views/*.php',
        './resources/views/**/*.blade.php',
        './resources/js/**/*.vue',
    ],

    theme: {
        extend: {
            fontFamily: {
                sans: ['Nunito', ...defaultTheme.fontFamily.sans],
            },
            colors: {
                brand: colors.red,
            }
        },
    },

    plugins: [require('@tailwindcss/forms')],
};

```

<img width="220" alt="image" src="https://user-images.githubusercontent.com/1248035/178563489-eb288ed7-fe80-4f43-b5ff-a947cceb856c.png">

<img width="545" alt="image" src="https://user-images.githubusercontent.com/1248035/178563628-e9753319-52cd-4f82-b014-6a70644769f1.png">
