### PR TITLE
[1.x] Validate the stack argument

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -47,7 +47,7 @@ class InstallCommand extends Command
             return $this->installBladeStack();
         }
 
-        $this->components->error('The stack must be blade, react, vue, or api.');
+        $this->components->error('Invalid stack. Supported stacks are [blade], [react], [vue], and [api].');
 
         return 1;
     }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -33,7 +33,7 @@ class InstallCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int|null
      */
     public function handle()
     {
@@ -43,9 +43,13 @@ class InstallCommand extends Command
             return $this->installInertiaReactStack();
         } elseif ($this->argument('stack') === 'api') {
             return $this->installApiStack();
-        } else {
+        } elseif ($this->argument('stack') === 'blade') {
             return $this->installBladeStack();
         }
+
+        $this->components->error('The stack must be blade, react, vue, or api.');
+
+        return 1;
     }
 
     /**


### PR DESCRIPTION
Currently, when running `breeze:install`, if you specify an invalid stack argument, you will get the Blade stack. This is confusing if you typo the stack (e.g. `vu`).

This PR is related to the Jetstream PR at https://github.com/laravel/jetstream/pull/1113, with the main difference being that Breeze has a default argument of "blade" for the `stack` argument.