### PR TITLE
Set application home URI to /dashboard

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -36,6 +36,7 @@ trait InstallsApiStack
 
         // Providers...
         $files->copyDirectory(__DIR__.'/../../stubs/api/App/Providers', app_path('Providers'));
+        $this->replaceInFile("HOME = '/home'", "HOME = '/dashboard'", app_path('Providers/RouteServiceProvider.php'));
 
         // Routes...
         copy(__DIR__.'/../../stubs/api/routes/api.php', base_path('routes/api.php'));


### PR DESCRIPTION
At the moment, when email verification is enabled on the API/Next.js stack, the email verification links with the default URI structure (`http://localhost:8000/verify-email/xx/xx?expires=xx&signature=xx`) redirect to `http://locahost:3000/home?verified=1` which does not exist and thus, a 404 page gets rendered.

This MR sets the application home URI to `/dashboard` as a more reasonable default value since the `/home` URI does not exist by default but `/dashboard` exists on the Breeze Next.js example app. Alternatively, this could be set to `/` as this URL should be available on most apps. This then will be used by the `VerifyEmailController` for redirection to `config('app.frontend_url').RouteServiceProvider::HOME.'?verified=1'`.