### PR TITLE
update registration tests

### DIFF
--- a/stubs/api/tests/Feature/RegistrationTest.php
+++ b/stubs/api/tests/Feature/RegistrationTest.php
@@ -11,6 +11,10 @@ class RegistrationTest extends TestCase
 
     public function test_new_users_can_register()
     {
+        if (! Route::has('register')) {
+            $this->markTestSkipped('Registration route not found.');
+        }
+
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',

--- a/stubs/api/tests/Feature/RegistrationTest.php
+++ b/stubs/api/tests/Feature/RegistrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase

--- a/stubs/default/tests/Feature/RegistrationTest.php
+++ b/stubs/default/tests/Feature/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Auth;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
@@ -12,6 +13,10 @@ class RegistrationTest extends TestCase
 
     public function test_registration_screen_can_be_rendered()
     {
+        if (! Route::has('register')) {
+            $this->markTestSkipped('Registration route not found.');
+        }
+
         $response = $this->get('/register');
 
         $response->assertStatus(200);
@@ -19,6 +24,10 @@ class RegistrationTest extends TestCase
 
     public function test_new_users_can_register()
     {
+        if (! Route::has('register')) {
+            $this->markTestSkipped('Registration route not found.');
+        }
+
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',


### PR DESCRIPTION
Similar to [Jetstream Registration Tests](https://github.com/laravel/jetstream/blob/2.x/stubs/tests/RegistrationTest.php#L17), This PR allows users to skip registration tests without throwing an error, if the user tried to disable the registration routes

In fact, the users can just remove the registration test file directly, but sometimes in some applications, they just disable the registration routes temporarily, in hope to get them back in the future. So, it's easy to skip tests while the registration is disabled instead of remove them entirely.