### PR TITLE
Use existing NPM package manager when installing Breeze dependencies

### DIFF
--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -15,9 +15,16 @@ trait InstallsBladeStack
     {
         // Get NPM Package Manager...
         $npmPackageManager = (function () {
-            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) return 'npm';
-            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) return 'pnpm';
-            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) return 'yarn';
+            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) {
+                return 'npm';
+            }
+            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) {
+                return 'pnpm';
+            }
+            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) {
+                return 'yarn';
+            }
+            
             return 'npm';
         })();
 

--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -15,16 +15,16 @@ trait InstallsBladeStack
     {
         // Get NPM Package Manager...
         $npmPackageManager = (function () {
-            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) {
+            if ((new Filesystem)->exists(base_path().'/package-lock.json')) {
                 return 'npm';
             }
-            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) {
+            if ((new Filesystem)->exists(base_path().'/pnpm-lock.yaml')) {
                 return 'pnpm';
             }
-            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) {
+            if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
                 return 'yarn';
             }
-            
+
             return 'npm';
         })();
 

--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -13,6 +13,14 @@ trait InstallsBladeStack
      */
     protected function installBladeStack()
     {
+        // Get NPM Package Manager...
+        $npmPackageManager = (function () {
+            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) return 'npm';
+            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) return 'pnpm';
+            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) return 'yarn';
+            return 'npm';
+        })();
+
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
@@ -66,7 +74,10 @@ trait InstallsBladeStack
         copy(__DIR__.'/../../stubs/default/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/default/resources/js/app.js', resource_path('js/app.js'));
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Install and Build NPM Packages...
+        $this->line('');
+        $this->components->info("Installing $npmPackageManager packages.");
+        $this->runCommands(["$npmPackageManager install", "$npmPackageManager run build"]);
 
         $this->line('');
         $this->components->info('Breeze scaffolding installed successfully.');

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -16,9 +16,16 @@ trait InstallsInertiaStacks
     {
         // Get NPM Package Manager...
         $npmPackageManager = (function () {
-            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) return 'npm';
-            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) return 'pnpm';
-            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) return 'yarn';
+            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) {
+                return 'npm';
+            }
+            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) {
+                return 'pnpm';
+            }
+            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) {
+                return 'yarn';
+            }
+            
             return 'npm';
         })();
 
@@ -136,9 +143,16 @@ trait InstallsInertiaStacks
     {
         // Get NPM Package Manager...
         $npmPackageManager = (function () {
-            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) return 'npm';
-            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) return 'pnpm';
-            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) return 'yarn';
+            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) {
+                return 'npm';
+            }
+            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) {
+                return 'pnpm';
+            }
+            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) {
+                return 'yarn';
+            }
+            
             return 'npm';
         })();
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -14,6 +14,14 @@ trait InstallsInertiaStacks
      */
     protected function installInertiaVueStack()
     {
+        // Get NPM Package Manager...
+        $npmPackageManager = (function () {
+            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) return 'npm';
+            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) return 'pnpm';
+            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) return 'yarn';
+            return 'npm';
+        })();
+
         // Install Inertia...
         $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0');
 
@@ -81,7 +89,10 @@ trait InstallsInertiaStacks
             $this->installInertiaVueSsrStack();
         }
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Install and Build NPM Packages...
+        $this->line('');
+        $this->components->info("Installing $npmPackageManager packages.");
+        $this->runCommands(["$npmPackageManager install", "$npmPackageManager run build"]);
 
         $this->line('');
         $this->components->info('Breeze scaffolding installed successfully.');
@@ -123,6 +134,14 @@ trait InstallsInertiaStacks
      */
     protected function installInertiaReactStack()
     {
+        // Get NPM Package Manager...
+        $npmPackageManager = (function () {
+            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) return 'npm';
+            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) return 'pnpm';
+            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) return 'yarn';
+            return 'npm';
+        })();
+
         // Install Inertia...
         $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0');
 
@@ -199,7 +218,10 @@ trait InstallsInertiaStacks
             $this->installInertiaReactSsrStack();
         }
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Install and Build NPM Packages...
+        $this->line('');
+        $this->components->info("Installing $npmPackageManager packages.");
+        $this->runCommands(["$npmPackageManager install", "$npmPackageManager run build"]);
 
         $this->line('');
         $this->components->info('Breeze scaffolding installed successfully.');

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -25,7 +25,7 @@ trait InstallsInertiaStacks
             if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
                 return 'yarn';
             }
-            
+
             return 'npm';
         })();
 
@@ -152,7 +152,7 @@ trait InstallsInertiaStacks
             if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
                 return 'yarn';
             }
-            
+
             return 'npm';
         })();
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -16,13 +16,13 @@ trait InstallsInertiaStacks
     {
         // Get NPM Package Manager...
         $npmPackageManager = (function () {
-            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) {
+            if ((new Filesystem)->exists(base_path().'/package-lock.json')) {
                 return 'npm';
             }
-            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) {
+            if ((new Filesystem)->exists(base_path().'/pnpm-lock.yaml')) {
                 return 'pnpm';
             }
-            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) {
+            if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
                 return 'yarn';
             }
             
@@ -143,13 +143,13 @@ trait InstallsInertiaStacks
     {
         // Get NPM Package Manager...
         $npmPackageManager = (function () {
-            if ((new Filesystem)->exists(base_path() . '/package-lock.json')) {
+            if ((new Filesystem)->exists(base_path().'/package-lock.json')) {
                 return 'npm';
             }
-            if ((new Filesystem)->exists(base_path() . '/pnpm-lock.yaml')) {
+            if ((new Filesystem)->exists(base_path().'/pnpm-lock.yaml')) {
                 return 'pnpm';
             }
-            if ((new Filesystem)->exists(base_path() . '/yarn.lock')) {
+            if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
                 return 'yarn';
             }
             


### PR DESCRIPTION
PR https://github.com/laravel/breeze/pull/180 added functionality to automatically install NPM packages and builds your assets. However, it defaults to using `npm` instead of the package manager you are currently using in your project (like pnpm or yarn).

This PR adds functionality to check if you are already using a package manager for your project and uses that to install Breeze dependencies. If you aren't using a package manager, it defaults to `npm`.