### PR TITLE
[1.x] Make Blade app header optional

### DIFF
--- a/stubs/default/resources/views/layouts/app.blade.php
+++ b/stubs/default/resources/views/layouts/app.blade.php
@@ -18,11 +18,13 @@
             @include('layouts.navigation')
 
             <!-- Page Heading -->
-            <header class="bg-white shadow">
-                <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                    {{ $header }}
-                </div>
-            </header>
+            @if (isset($header))
+                <header class="bg-white shadow">
+                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                        {{ $header }}
+                    </div>
+                </header>
+            @endif
 
             <!-- Page Content -->
             <main>


### PR DESCRIPTION
In the Vue and React stacks, the `header` slot on the authenticated layout is optional:

https://github.com/laravel/breeze/blob/c478aba7fb64b93ae1f7d6ca3f47a9a87f31f8aa/stubs/inertia-vue/resources/js/Layouts/AuthenticatedLayout.vue#L97-L102

https://github.com/laravel/breeze/blob/c478aba7fb64b93ae1f7d6ca3f47a9a87f31f8aa/stubs/inertia-react/resources/js/Layouts/AuthenticatedLayout.jsx#L114-L118

This PR updates the Blade app layout to be the same.