### PR TITLE
[1.x] Consistently use `verified` middleware on `/dashboard` route.

### DIFF
--- a/stubs/default/routes/web.php
+++ b/stubs/default/routes/web.php
@@ -19,6 +19,6 @@ Route::get('/', function () {
 
 Route::get('/dashboard', function () {
     return view('dashboard');
-})->middleware(['auth'])->name('dashboard');
+})->middleware(['auth', 'verified'])->name('dashboard');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
The Vue and React stacks have the `verified` middleware on the `/dashboard` route by default:

https://github.com/laravel/breeze/blob/c478aba7fb64b93ae1f7d6ca3f47a9a87f31f8aa/stubs/inertia-common/routes/web.php#L27-L29

This PR updates the Blade stack to be the same. Note that it only takes effect if the `MustVerifyEmail` interface is implemented on the `User` model.

It's obviously a personal preference whether or not the dashboard should require verification, so an alternative would be to remove it from the other stacks. Personally, I like that it's there by default as it's safer and demonstrates a feature that Breeze provides UI components for.