### PR TITLE
Upgrade to React 18

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -138,8 +138,8 @@ trait InstallsInertiaStacks
                 'autoprefixer' => '^10.4.2',
                 'postcss' => '^8.4.6',
                 'tailwindcss' => '^3.1.0',
-                'react' => '^17.0.2',
-                'react-dom' => '^17.0.2',
+                'react' => '^18.2.0',
+                'react-dom' => '^18.2.0',
             ] + $packages;
         });
 

--- a/stubs/inertia-react/resources/js/app.jsx
+++ b/stubs/inertia-react/resources/js/app.jsx
@@ -2,7 +2,7 @@ import './bootstrap';
 import '../css/app.css';
 
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from "react-dom/client";
 import { createInertiaApp } from '@inertiajs/inertia-react';
 import { InertiaProgress } from '@inertiajs/progress';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
@@ -13,7 +13,9 @@ createInertiaApp({
     title: (title) => `${title} - ${appName}`,
     resolve: (name) => resolvePageComponent(`./Pages/${name}.jsx`, import.meta.glob('./Pages/**/*.jsx')),
     setup({ el, App, props }) {
-        return render(<App {...props} />, el);
+        const root = createRoot(el);
+
+        root.render(<App {...props} />);
     },
 });
 


### PR DESCRIPTION
The current breeze react stack uses old React 17 version. Inertia has recently released full support for React 18.

This PR simply updates the package json to react 18 and uses the react 18 `createRoot` api which is all that is required to make it work.