### PR TITLE
Fixes `HandleInertiaRequests::handle` related types.

### DIFF
--- a/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
@@ -30,7 +30,7 @@ class HandleInertiaRequests extends Middleware
      * Define the props that are shared by default.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return array<string, mixed>
      */
     public function share(Request $request)
     {

--- a/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
@@ -30,7 +30,7 @@ class HandleInertiaRequests extends Middleware
      * Define the props that are shared by default.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array<string, mixed>
+     * @return mixed[]
      */
     public function share(Request $request)
     {


### PR DESCRIPTION
This pull request fixes the `HandleInertiaRequests::handle` related types.

Note, the type is mixed[], because array<string, mixed> would be technically incorrect as passing an integer as a key is theoretically supported.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
