### PR TITLE
Replace double quote(") with single quote(')

### DIFF
--- a/stubs/inertia-vue/resources/js/Components/Checkbox.vue
+++ b/stubs/inertia-vue/resources/js/Components/Checkbox.vue
@@ -19,7 +19,7 @@ const proxyChecked = computed({
     },
 
     set(val) {
-        emit("update:checked", val);
+        emit('update:checked', val);
     },
 });
 </script>


### PR DESCRIPTION
All VueJS components use a **single quote (')** for string but in **Checkbox. Vue** Line 22 uses a **double quote(")**

It makes it **inconsistent** with others.

