### PR TITLE
RegisteredUserController stubs should use the User model name instead of table name in the validators

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -24,7 +24,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -24,7 +24,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -35,7 +35,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -35,7 +35,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -36,7 +36,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:' . User::class,
+            'email' => 'required|string|email|max:255|unique:'.User::class,
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -36,7 +36,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:users',
+            'email' => 'required|string|email|max:255|unique:' . User::class,
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 


### PR DESCRIPTION
The validators in `RegisteredUserController` stubs should reference the User model name instead of table name to avoid  error throw when registering a new user and the table name defined in `App\Models\User` consists of `database schema` + `table name`.

**Use case**

Configure the `App\Models\User` class with a not default database schema as table name:

```php
protected $table = "foobar.users";
```

Try to register a new user and then the error occur:

```sql
SQLSTATE[42P01]: Undefined table: 7 ERROR: relation "users" does not exist LINE 1: 
  select count(*) as aggregate of "users" where "email" = $1
```