### PR TITLE
Make Profile Pages Translatable

### DIFF
--- a/stubs/default/resources/views/profile/partials/delete-user-form.blade.php
+++ b/stubs/default/resources/views/profile/partials/delete-user-form.blade.php
@@ -1,21 +1,21 @@
 <section class="space-y-6">
     <header>
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Delete Account</h2>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.</p>
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Delete Account') }}</h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}</p>
     </header>
 
     <x-danger-button
         x-data=""
         x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')"
-    >Delete Account</x-danger-button>
+    >{{__('Delete Account')}}</x-danger-button>
 
     <x-modal name="confirm-user-deletion" :show="$errors->userDeletion->isNotEmpty()" focusable>
         <form method="post" action="{{ route('profile.destroy') }}" class="p-6">
             @csrf
             @method('delete')
 
-            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Are you sure your want to delete your account?</h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.</p>
+            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Are you sure your want to delete your account?') }}</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}</p>
 
             <div class="mt-6">
                 <x-input-label for="password" value="Password" class="sr-only" />

--- a/stubs/default/resources/views/profile/partials/update-password-form.blade.php
+++ b/stubs/default/resources/views/profile/partials/update-password-form.blade.php
@@ -1,7 +1,7 @@
 <section>
     <header>
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Update Password</h2>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Ensure your account is using a long, random password to stay secure.</p>
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Update Password') }}</h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('Ensure your account is using a long, random password to stay secure.') }}</p>
     </header>
 
     <form method="post" action="{{ route('password.update') }}" class="mt-6 space-y-6">
@@ -36,7 +36,7 @@
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
                     class="text-sm text-gray-600 dark:text-gray-400"
-                >Saved.</p>
+                >{{ __('Saved.') }}</p>
             @endif
         </div>
     </form>

--- a/stubs/default/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/stubs/default/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,7 +1,7 @@
 <section>
     <header>
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Profile Information</h2>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Update your account's profile information and email address.</p>
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Profile Information') }}</h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('Update your account\'s profile information and email address.') }}</p>
     </header>
 
     <form id="send-verification" method="post" action="{{ route('verification.send') }}">
@@ -26,7 +26,7 @@
             @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
                 <div>
                     <p class="text-sm mt-2 text-gray-800 dark:text-gray-200">
-                        Your email address is unverified.
+                        {{ __('Your email address is unverified.') }}"
 
                         <button form="send-verification" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">
                             {{ __('Click here to re-send the verification email.') }}
@@ -52,7 +52,7 @@
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
                     class="text-sm text-gray-600 dark:text-gray-400"
-                >Saved.</p>
+                >{{ __('Saved.') }}</p>
             @endif
         </div>
     </form>


### PR DESCRIPTION
Hi!

I just noticed that some of newly added Profile page's texts are not translatable.
So I added `{{ __('text here') }}` to each texts so that we can easily support multi languages in the Profile Page.