### PR TITLE
Add Confirm Password in API

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/api/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Providers\RouteServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;

--- a/stubs/api/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/api/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+
+class ConfirmablePasswordController extends Controller
+{
+    /**
+     * Confirm the user's password.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        if (! Auth::guard('web')->validate([
+            'email' => $request->user()->email,
+            'password' => $request->password,
+        ])) {
+            throw ValidationException::withMessages([
+                'password' => trans('auth.password'),
+            ]);
+        }
+
+        $request->session()->put('auth.password_confirmed_at', time());
+
+        return response()->noContent();
+    }
+}

--- a/stubs/api/pest-tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/stubs/api/pest-tests/Feature/Auth/PasswordConfirmationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\User;
+
+test('password can be confirmed', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/confirm-password', [
+        'password' => 'password',
+    ]);
+
+    $response->assertNoContent();
+    $response->assertSessionHasNoErrors();
+});
+
+test('password is not confirmed with invalid password', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/confirm-password', [
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertSessionHasErrors();
+});

--- a/stubs/api/routes/auth.php
+++ b/stubs/api/routes/auth.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Auth\ConfirmablePasswordController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
@@ -23,12 +24,6 @@ Route::middleware('guest')->group(function () {
 });
 
 Route::middleware('auth')->group(function () {
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
-        ->name('password.confirm');
-
-    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-        ->name('logout');
-
     Route::middleware('throttle:6,1')->group(function () {
         Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
             ->middleware('signed')
@@ -37,4 +32,10 @@ Route::middleware('auth')->group(function () {
         Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
             ->name('verification.send');
     });
+
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->name('password.confirm');
+
+    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+        ->name('logout');
 });

--- a/stubs/api/routes/auth.php
+++ b/stubs/api/routes/auth.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
-use App\Http\Controllers\Auth\ConfirmablePasswordController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
@@ -9,33 +8,34 @@ use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware('guest')->group(function () {
-    Route::post('/register', [RegisteredUserController::class, 'store'])
-        ->name('register');
+Route::post('/register', [RegisteredUserController::class, 'store'])
+                ->middleware('guest')
+                ->name('register');
 
-    Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-        ->name('login');
+Route::post('/login', [AuthenticatedSessionController::class, 'store'])
+                ->middleware('guest')
+                ->name('login');
 
-    Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-        ->name('password.email');
+Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
+                ->middleware('guest')
+                ->name('password.email');
 
-    Route::post('/reset-password', [NewPasswordController::class, 'store'])
-        ->name('password.store');
-});
+Route::post('/reset-password', [NewPasswordController::class, 'store'])
+                ->middleware('guest')
+                ->name('password.store');
 
-Route::middleware('auth')->group(function () {
-    Route::middleware('throttle:6,1')->group(function () {
-        Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-            ->middleware('signed')
-            ->name('verification.verify');
+Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+                ->middleware('auth')
+                ->name('password.confirm');
 
-        Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-            ->name('verification.send');
-    });
+Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+                ->middleware(['auth', 'signed', 'throttle:6,1'])
+                ->name('verification.verify');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
-        ->name('password.confirm');
+Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+                ->middleware(['auth', 'throttle:6,1'])
+                ->name('verification.send');
 
-    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-        ->name('logout');
-});
+Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+                ->middleware('auth')
+                ->name('logout');

--- a/stubs/api/routes/auth.php
+++ b/stubs/api/routes/auth.php
@@ -8,30 +8,33 @@ use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
-Route::post('/register', [RegisteredUserController::class, 'store'])
-                ->middleware('guest')
-                ->name('register');
+Route::middleware('guest')->group(function () {
+    Route::post('/register', [RegisteredUserController::class, 'store'])
+        ->name('register');
 
-Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-                ->middleware('guest')
-                ->name('login');
+    Route::post('/login', [AuthenticatedSessionController::class, 'store'])
+        ->name('login');
 
-Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.email');
+    Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
+        ->name('password.email');
 
-Route::post('/reset-password', [NewPasswordController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.store');
+    Route::post('/reset-password', [NewPasswordController::class, 'store'])
+        ->name('password.store');
+});
 
-Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-                ->middleware(['auth', 'signed', 'throttle:6,1'])
-                ->name('verification.verify');
+Route::middleware('auth')->group(function () {
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->name('password.confirm');
 
-Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware(['auth', 'throttle:6,1'])
-                ->name('verification.send');
+    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+        ->name('logout');
 
-Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->middleware('auth')
-                ->name('logout');
+    Route::middleware('throttle:6,1')->group(function () {
+        Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+            ->middleware('signed')
+            ->name('verification.verify');
+
+        Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+            ->name('verification.send');
+    });
+});

--- a/stubs/api/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/stubs/api/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PasswordConfirmationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_password_can_be_confirmed()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/confirm-password', [
+            'password' => 'password',
+        ]);
+
+        $response->assertNoContent();
+        $response->assertSessionHasNoErrors();
+    }
+
+    public function test_password_is_not_confirmed_with_invalid_password()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/confirm-password', [
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertSessionHasErrors();
+    }
+}


### PR DESCRIPTION
This PR adds the route to confirm the password if the user wants to use it in his API.

It's a feature that Laravel Breeze already has, except in its API option.

Tests have been added.