### PR TITLE
status must be String

### DIFF
--- a/stubs/inertia-vue/resources/js/Pages/Profile/Edit.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Profile/Edit.vue
@@ -7,7 +7,7 @@ import { Head } from '@inertiajs/inertia-vue3';
 
 defineProps({
     mustVerifyEmail: Boolean,
-    status: Boolean,
+    status: String,
 });
 </script>
 


### PR DESCRIPTION
The variable status must be string because in component UpdateProfileInformationForm, status is string.