### PR TITLE
Update NewPasswordController.php redirect to new helper function

### DIFF
--- a/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
@@ -58,7 +58,7 @@ class NewPasswordController extends Controller
         // the application's home authenticated view. If there is an error we can
         // redirect them back to where they came from with their error message.
         return $status == Password::PASSWORD_RESET
-                    ? redirect()->route('login')->with('status', __($status))
+                    ? to_route('login')->with('status', __($status))
                     : back()->withInput($request->only('email'))
                             ->withErrors(['email' => __($status)]);
     }


### PR DESCRIPTION
Update the `redirect()->route` to use the new Laravel 9 helper function `to_route` instead. Came across it when I did a search on one of my apps to update old references to `redirect()->route`
