### PR TITLE
[1.x] Blade stack - added link to registration from login page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
-.idea

--- a/stubs/default/resources/views/auth/confirm-password.blade.php
+++ b/stubs/default/resources/views/auth/confirm-password.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
             {{ __('This is a secure area of the application. Please confirm your password before continuing.') }}
         </div>

--- a/stubs/default/resources/views/auth/forgot-password.blade.php
+++ b/stubs/default/resources/views/auth/forgot-password.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
             {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
         </div>

--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <!-- Session Status -->
         <x-auth-session-status class="mb-4" :status="session('status')" />
 

--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -48,7 +48,7 @@
     </x-auth-card>
 
     @if (Route::has('register'))
-        <div class="text-sm pt-5 text-center text-gray-600">{{ __("Don't have an account yet?") }} <a
+        <div class="text-sm my-4 text-center text-gray-600">{{ __("Don't have an account yet?") }} <a
                 href="{{ route('register') }}"
                 class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">{{ __("Register here!") }}</a>
         </div>

--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -46,4 +46,11 @@
             </div>
         </form>
     </x-auth-card>
+
+    @if (Route::has('register'))
+        <div class="text-sm pt-5 text-center text-gray-600">{{ __("Don't have an account yet?") }} <a
+                href="{{ route('register') }}"
+                class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">{{ __("Register here!") }}</a>
+        </div>
+    @endif
 </x-guest-layout>

--- a/stubs/default/resources/views/auth/register.blade.php
+++ b/stubs/default/resources/views/auth/register.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <form method="POST" action="{{ route('register') }}">
             @csrf
 

--- a/stubs/default/resources/views/auth/reset-password.blade.php
+++ b/stubs/default/resources/views/auth/reset-password.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <form method="POST" action="{{ route('password.store') }}">
             @csrf
 

--- a/stubs/default/resources/views/auth/verify-email.blade.php
+++ b/stubs/default/resources/views/auth/verify-email.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
             {{ __('Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}
         </div>

--- a/stubs/default/resources/views/components/auth-card.blade.php
+++ b/stubs/default/resources/views/components/auth-card.blade.php
@@ -1,9 +1,3 @@
-<div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100 dark:bg-gray-900">
-    <div>
-        {{ $logo }}
-    </div>
-
-    <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
-        {{ $slot }}
-    </div>
+<div class="w-full px-6 py-4 bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
+    {{ $slot }}
 </div>

--- a/stubs/default/resources/views/layouts/guest.blade.php
+++ b/stubs/default/resources/views/layouts/guest.blade.php
@@ -13,9 +13,17 @@
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
-    <body>
-        <div class="font-sans text-gray-900 antialiased">
-            {{ $slot }}
+    <body class="font-sans text-gray-900 antialiased">
+        <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100 dark:bg-gray-900">
+            <div>
+                <a href="/">
+                    <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
+                </a>
+            </div>
+
+            <div class="w-full sm:max-w-md mt-6">
+                {{ $slot }}
+            </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
it's very common for websites to offer a link for registration from within the login page.

in this pull request I've made the following changes to the Blade stack:

- Moved duplicated logo component to guest layout
- Added link to registration from login page

![Laravel Breeze](https://static.momagdi.com/Breeze-Register-Here.png)