### PR TITLE
Fixed capitalization of autoComplete prop

### DIFF
--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
@@ -57,7 +57,7 @@ export default function UpdatePasswordForm({ className }) {
                         handleChange={(e) => setData('current_password', e.target.value)}
                         type="password"
                         className="mt-1 block w-full"
-                        autocomplete="current-password"
+                        autoComplete="current-password"
                     />
 
                     <InputError message={errors.current_password} className="mt-2" />
@@ -73,7 +73,7 @@ export default function UpdatePasswordForm({ className }) {
                         handleChange={(e) => setData('password', e.target.value)}
                         type="password"
                         className="mt-1 block w-full"
-                        autocomplete="new-password"
+                        autoComplete="new-password"
                     />
 
                     <InputError message={errors.password} className="mt-2" />
@@ -88,7 +88,7 @@ export default function UpdatePasswordForm({ className }) {
                         handleChange={(e) => setData('password_confirmation', e.target.value)}
                         type="password"
                         className="mt-1 block w-full"
-                        autocomplete="new-password"
+                        autoComplete="new-password"
                     />
 
                     <InputError message={errors.password_confirmation} className="mt-2" />

--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -40,7 +40,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                         handleChange={(e) => setData('name', e.target.value)}
                         required
                         autofocus
-                        autocomplete="name"
+                        autoComplete="name"
                     />
 
                     <InputError className="mt-2" message={errors.name} />
@@ -56,7 +56,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                         value={data.email}
                         handleChange={(e) => setData('email', e.target.value)}
                         required
-                        autocomplete="email"
+                        autoComplete="email"
                     />
 
                     <InputError className="mt-2" message={errors.email} />


### PR DESCRIPTION
Noticed I was getting warnings in the dev console so I fixed spelling/capitalization of the autoComplete prop within the TextInput.jsx component. Fixed both component references in UpdatePasswordForm.jsx and UpdateProfileInformationForm.jsx. No longer receiving warning in the dev console. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
