### PR TITLE
Remove unused vue imports

### DIFF
--- a/stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -5,7 +5,7 @@ import InputLabel from '@/Components/InputLabel.vue';
 import Modal from '@/Components/Modal.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
-import { useForm, usePage } from '@inertiajs/inertia-vue3';
+import { useForm } from '@inertiajs/inertia-vue3';
 import { nextTick, ref } from 'vue';
 
 const confirmingUserDeletion = ref(false);

--- a/stubs/inertia-vue/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -4,7 +4,6 @@ import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
 import { Link, useForm, usePage } from '@inertiajs/inertia-vue3';
-import { ref } from 'vue';
 
 const props = defineProps({
     mustVerifyEmail: Boolean,


### PR DESCRIPTION
When running eslint a few errors are presented.

```
resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
7:10  error  'ref' is defined but never used  no-unused-vars
```
```
/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
8:19  error  'usePage' is defined but never used  no-unused-vars
```

I double checked and yeah not used within those components.