### PR TITLE
Renamed isFocused prop on TextInput component

### DIFF
--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -39,7 +39,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                         value={data.name}
                         handleChange={(e) => setData('name', e.target.value)}
                         required
-                        autofocus
+                        isFocused
                         autoComplete="name"
                     />
 


### PR DESCRIPTION
autofocus does not exist as a prop on the [TextInput](https://github.com/laravel/breeze/blob/1.x/stubs/inertia-react/resources/js/Components/TextInput.jsx) component. Renaming the prop to isFocused results in the text input auto focusing. 

Thanks. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
