### PR TITLE
[1.x] Laravel v10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         stack: [blade, react, vue, api]
-        laravel: [9, 10]
+        laravel: [^9, dev-master]
         args: [null, --pest]
         include:
           - stack: vue
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Laravel
         run: |
-          composer create-project laravel/laravel:^${{ matrix.laravel }} .
+          composer create-project laravel/laravel:${{ matrix.laravel }} .
           composer require laravel/breeze:* --no-interaction --no-update
           composer config repositories.breeze '{"type": "path", "url": "breeze"}' --file composer.json
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         stack: [blade, react, vue, api]
+        laravel: [9, 10]
         args: [null, --pest]
         include:
           - stack: vue
@@ -24,7 +25,7 @@ jobs:
           - stack: react
             args: --ssr
 
-    name: Test Stubs - ${{ matrix.stack }} ${{ matrix.args }}
+    name: Test Stubs - Laravel ${{ matrix.stack }} - ${{ matrix.stack }} ${{ matrix.args }}
 
     steps:
       - name: Setup PHP
@@ -38,7 +39,7 @@ jobs:
 
       - name: Setup Laravel
         run: |
-          composer create-project laravel/laravel:^9 .
+          composer create-project laravel/laravel:^${{ matrix.stack }} .
           composer require laravel/breeze:* --no-interaction --no-update
           composer config repositories.breeze '{"type": "path", "url": "breeze"}' --file composer.json
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         stack: [blade, react, vue, api]
-        laravel: [^9, dev-master]
+        laravel: [9, 10]
         args: [null, --pest]
         include:
           - stack: vue
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Laravel
         run: |
-          composer create-project laravel/laravel:${{ matrix.laravel }} .
+          composer create-project laravel/laravel:^${{ matrix.laravel }} .
           composer require laravel/breeze:* --no-interaction --no-update
           composer config repositories.breeze '{"type": "path", "url": "breeze"}' --file composer.json
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         stack: [blade, react, vue, api]
-        laravel: [9, 10]
+        laravel: [^9, 10.x-dev]
         args: [null, --pest]
         include:
           - stack: vue
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Laravel
         run: |
-          composer create-project laravel/laravel:^${{ matrix.laravel }} .
+          composer create-project laravel/laravel:${{ matrix.laravel }} .
           composer require laravel/breeze:* --no-interaction --no-update
           composer config repositories.breeze '{"type": "path", "url": "breeze"}' --file composer.json
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           - stack: react
             args: --ssr
 
-    name: Test Stubs - Laravel ${{ matrix.stack }} - ${{ matrix.stack }} ${{ matrix.args }}
+    name: Test Stubs - Laravel ${{ matrix.laravel }} - ${{ matrix.stack }} ${{ matrix.args }}
 
     steps:
       - name: Setup PHP
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Laravel
         run: |
-          composer create-project laravel/laravel:^${{ matrix.stack }} .
+          composer create-project laravel/laravel:^${{ matrix.laravel }} .
           composer require laravel/breeze:* --no-interaction --no-update
           composer config repositories.breeze '{"type": "path", "url": "breeze"}' --file composer.json
 

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "illuminate/console": "^9.21",
-        "illuminate/filesystem": "^9.21",
-        "illuminate/support": "^9.21",
-        "illuminate/validation": "^9.21"
+        "illuminate/console": "^9.21|^10.0",
+        "illuminate/filesystem": "^9.21|^10.0",
+        "illuminate/support": "^9.21|^10.0",
+        "illuminate/validation": "^9.21|^10.0"
     },
     "conflict": {
         "laravel/framework": "<9.37.0"

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -111,7 +111,7 @@ class InstallCommand extends Command
      * Installs the given Composer Packages into the application.
      *
      * @param  mixed  $packages
-     * @return void
+     * @return bool
      */
     protected function requireComposerPackages($packages)
     {
@@ -126,7 +126,7 @@ class InstallCommand extends Command
             is_array($packages) ? $packages : func_get_args()
         );
 
-        (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
+        return ! (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
             ->setTimeout(null)
             ->run(function ($type, $output) {
                 $this->output->write($output);

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -11,12 +11,14 @@ trait InstallsInertiaStacks
     /**
      * Install the Inertia Vue Breeze stack.
      *
-     * @return void
+     * @return int|null
      */
     protected function installInertiaVueStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0');
+        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0')) {
+            return 1;
+        }
 
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
@@ -136,12 +138,14 @@ trait InstallsInertiaStacks
     /**
      * Install the Inertia React Breeze stack.
      *
-     * @return void
+     * @return int|null
      */
     protected function installInertiaReactStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0');
+        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0')) {
+            return 1;
+        }
 
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -16,7 +16,7 @@ trait InstallsInertiaStacks
     protected function installInertiaVueStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0')) {
+        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^3.2', 'tightenco/ziggy:^1.0')) {
             return 1;
         }
 
@@ -143,7 +143,7 @@ trait InstallsInertiaStacks
     protected function installInertiaReactStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^2.8', 'tightenco/ziggy:^1.0')) {
+        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^3.2', 'tightenco/ziggy:^1.0')) {
             return 1;
         }
 


### PR DESCRIPTION
This PR brings Laravel v10 support to Breeze.

I adjusted the install command to fail when it cannot resolve composer dependencies. Previously, this was lost in our CI build and it wasn't clear why Breeze couldn't be installed. Thanks to failing when composer dependencies cannot be resolved, I was able to find out Sanctum needed to be updated.