### PR TITLE
Inform about installing node dependencies

### DIFF
--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -68,6 +68,9 @@ trait InstallsBladeStack
         copy(__DIR__.'/../../stubs/default/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/default/resources/js/app.js', resource_path('js/app.js'));
 
+        
+        $message = 'We are installing and buillding the node dependencies. This will only happen once.';
+        $this->line('<info>$message</info>');
         if (file_exists(base_path('pnpm-lock.yaml'))) {
             $this->runCommands(['pnpm install', 'pnpm run build']);
         } elseif (file_exists(base_path('yarn.lock'))) {


### PR DESCRIPTION
It informs the user that we are installing node dependencies. It would justify the blank delay screen while installing node dependencies.

## Issue
When we are installing the breeze scaffold there are **_delays in installing node dependencies_**. There is no indication some processes are running and the user may find lost as it seems to be stuck command. 

## Fix
It would inform users that were installing node dependencies. 