### PR TITLE
Automatically send an email verification notification when a user changes their email

### DIFF
--- a/stubs/default/app/Http/Controllers/ProfileController.php
+++ b/stubs/default/app/Http/Controllers/ProfileController.php
@@ -30,6 +30,7 @@ class ProfileController extends Controller
 
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;
+            $request->user()->sendEmailVerificationNotification();
         }
 
         $request->user()->save();

--- a/stubs/inertia-common/app/Http/Controllers/ProfileController.php
+++ b/stubs/inertia-common/app/Http/Controllers/ProfileController.php
@@ -33,6 +33,7 @@ class ProfileController extends Controller
 
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;
+            $request->user()->sendEmailVerificationNotification();
         }
 
         $request->user()->save();


### PR DESCRIPTION
As a user I'd expect to automatically receive a verification email after I'm told to verify my email address.

This PR adds a call to the sendEmailVerificationNotification() method after a user's email has been set to null.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
