### PR TITLE
[1.x] Clean up route definition for Single Action Controllers

### DIFF
--- a/stubs/api/routes/auth.php
+++ b/stubs/api/routes/auth.php
@@ -24,7 +24,7 @@ Route::post('/reset-password', [NewPasswordController::class, 'store'])
                 ->middleware('guest')
                 ->name('password.store');
 
-Route::get('/verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+Route::get('/verify-email/{id}/{hash}', VerifyEmailController::class)
                 ->middleware(['auth', 'signed', 'throttle:6,1'])
                 ->name('verification.verify');
 

--- a/stubs/default/routes/auth.php
+++ b/stubs/default/routes/auth.php
@@ -36,10 +36,10 @@ Route::middleware('guest')->group(function () {
 });
 
 Route::middleware('auth')->group(function () {
-    Route::get('verify-email', [EmailVerificationPromptController::class, '__invoke'])
+    Route::get('verify-email', EmailVerificationPromptController::class)
                 ->name('verification.notice');
 
-    Route::get('verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+    Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
                 ->middleware(['signed', 'throttle:6,1'])
                 ->name('verification.verify');
 

--- a/stubs/inertia-common/routes/auth.php
+++ b/stubs/inertia-common/routes/auth.php
@@ -36,10 +36,10 @@ Route::middleware('guest')->group(function () {
 });
 
 Route::middleware('auth')->group(function () {
-    Route::get('verify-email', [EmailVerificationPromptController::class, '__invoke'])
+    Route::get('verify-email', EmailVerificationPromptController::class)
                 ->name('verification.notice');
 
-    Route::get('verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
+    Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
                 ->middleware(['signed', 'throttle:6,1'])
                 ->name('verification.verify');
 


### PR DESCRIPTION
Laravel added support for **[Single Action/Invokable Controller](https://laravel.com/docs/9.x/controllers#single-action-controllers)** since v5.6. According to the documentation:
> When registering routes for single action controllers, you do not need to specify a controller method. Instead, you may simply pass the name of the controller to the router

This PR cleans up the route files by removing the unnecessarily specified `__invoke` method for the __Single Action__ controllers. 

These changes should not cause any breaking changes.