### PR TITLE
[1.x] Add translation to placeholder in delete-user-form.blade.php

### DIFF
--- a/stubs/default/resources/views/profile/partials/delete-user-form.blade.php
+++ b/stubs/default/resources/views/profile/partials/delete-user-form.blade.php
@@ -35,7 +35,7 @@
                     name="password"
                     type="password"
                     class="mt-1 block w-3/4"
-                    placeholder="Password"
+                    placeholder="{{ __('Password') }}"
                 />
 
                 <x-input-error :messages="$errors->userDeletion->get('password')" class="mt-2" />


### PR DESCRIPTION
Just a small change that does same people some time that want to translate the placeholder for the password in the delete-user-form.blade.php
