### PR TITLE
[1.x] Allowed a hardcoded string to be localized

### DIFF
--- a/stubs/default/resources/views/profile/partials/delete-user-form.blade.php
+++ b/stubs/default/resources/views/profile/partials/delete-user-form.blade.php
@@ -28,7 +28,7 @@
             </p>
 
             <div class="mt-6">
-                <x-input-label for="password" value="Password" class="sr-only" />
+                <x-input-label for="password" value="{{ __('Password') }}" class="sr-only" />
 
                 <x-text-input
                     id="password"


### PR DESCRIPTION
A very tiny little change that allows a possibly-forgotten string of text to be localized.

Changed an _x-input-label_ attribute `value="Password"` to `value="{{ __('Password') }}"`.