### PR TITLE
Don't redirect in api mode if authenticated

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -21,6 +21,11 @@ trait InstallsApiStack
 
         // Middleware...
         $files->copyDirectory(__DIR__.'/../../stubs/api/app/Http/Middleware', app_path('Http/Middleware'));
+        $this->replaceInFile(
+            "if (Auth::guard(\$guard)->check()) {",
+            "if (Auth::guard(\$guard)->check() && !\$request->wantsJson()) {",
+            app_path('Http/Middleware/RedirectIfAuthenticated.php')
+        );
 
         $this->replaceInFile('// \Laravel\Sanctum\Http', '\Laravel\Sanctum\Http', app_path('Http/Kernel.php'));
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

A proposed improvement for the laravel/breeze package is for when it is installed in API mode, there will not be a redirect if the user is already authenticated. This change will ensure a better user experience.

It's possible to implement my own solution in Laravel, but if Breeze is installed with the --api flag, I think it would be appropriate to come this way.

## Screenshots
![image](https://user-images.githubusercontent.com/10859156/218610027-f4c7722f-34b3-4767-850b-571818ae16e3.png)
![image](https://user-images.githubusercontent.com/10859156/218610210-def29a53-5002-4710-a4f6-b31e7167874d.png)


