### PR TITLE
Remove pages ref from Vite in Vue

### DIFF
--- a/stubs/inertia-vue/resources/views/app.blade.php
+++ b/stubs/inertia-vue/resources/views/app.blade.php
@@ -12,7 +12,7 @@
 
         <!-- Scripts -->
         @routes
-        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @vite('resources/js/app.js')
         @inertiaHead
     </head>
     <body class="font-sans antialiased">


### PR DESCRIPTION
The inertia docs https://inertiajs.com/server-side-setup, recommend uses ```@Vite('resources/js/app.js')```.

The old way creates 502 errors because cannot render complex components on the build.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
