### PR TITLE
[1.x] Fix input field Id in ForgotPassword.jsx

### DIFF
--- a/stubs/inertia-react/resources/js/Pages/Auth/ForgotPassword.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Auth/ForgotPassword.jsx
@@ -32,7 +32,7 @@ export default function ForgotPassword({ status }) {
 
             <form onSubmit={submit}>
                 <TextInput
-                    id="password"
+                    id="email"
                     type="email"
                     name="email"
                     value={data.email}


### PR DESCRIPTION
The email field in the ForgotPassword form is wrongly labels as "password". This PR changes the field Id to "email". Like on the other Auth forms.