### PR TITLE
[1.x] Translations support for Inertia (Vue and React)

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -183,10 +183,12 @@ trait InstallsInertiaStacks
 
         // Components + Pages...
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Components'));
+        (new Filesystem)->ensureDirectoryExists(resource_path('js/Contexts'));
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Layouts'));
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Pages'));
 
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-react/resources/js/Components', resource_path('js/Components'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-react/resources/js/Contexts', resource_path('js/Contexts'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-react/resources/js/Layouts', resource_path('js/Layouts'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-react/resources/js/Pages', resource_path('js/Pages'));
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -36,6 +36,10 @@ trait InstallsInertiaStacks
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/app/Http/Controllers', app_path('Http/Controllers'));
 
+        // Trait...
+        (new Filesystem)->ensureDirectoryExists(app_path('Traits'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/app/Traits', app_path('Traits'));
+
         // Requests...
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Requests'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/default/app/Http/Requests', app_path('Http/Requests'));
@@ -157,6 +161,10 @@ trait InstallsInertiaStacks
         // Controllers...
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/app/Http/Controllers', app_path('Http/Controllers'));
+
+        // Trait...
+        (new Filesystem)->ensureDirectoryExists(app_path('Traits'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/app/Traits', app_path('Traits'));
 
         // Requests...
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Requests'));

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -57,10 +57,12 @@ trait InstallsInertiaStacks
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Components'));
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Layouts'));
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Pages'));
+        (new Filesystem)->ensureDirectoryExists(resource_path('js/Plugins'));
 
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-vue/resources/js/Components', resource_path('js/Components'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-vue/resources/js/Layouts', resource_path('js/Layouts'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-vue/resources/js/Pages', resource_path('js/Pages'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-vue/resources/js/Plugins', resource_path('js/Plugins'));
 
         if (! $this->option('dark')) {
             $this->removeDarkClasses((new Finder)

--- a/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,12 +2,15 @@
 
 namespace App\Http\Middleware;
 
+use App\Traits\Translations;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Tightenco\Ziggy\Ziggy;
 
 class HandleInertiaRequests extends Middleware
 {
+    use Translations;
+
     /**
      * The root template that is loaded on the first page visit.
      *
@@ -39,6 +42,7 @@ class HandleInertiaRequests extends Middleware
                     'location' => $request->url(),
                 ]);
             },
+            'translations' => $this->translations(),
         ]);
     }
 }

--- a/stubs/inertia-common/app/Traits/Translations.php
+++ b/stubs/inertia-common/app/Traits/Translations.php
@@ -23,7 +23,7 @@ trait Translations
             if (File::exists(base_path("lang/$locale"))) {
                 $phpTranslations = collect(File::allFiles(base_path("lang/$locale")))
                     ->filter(function ($file) {
-                        return $file->getExtension() === "php";
+                        return $file->getExtension() === 'php';
                     })->flatMap(function ($file) {
                         return Arr::dot([$file->getFilenameWithoutExtension() => File::getRequire($file->getRealPath())]);
                     })->toArray();

--- a/stubs/inertia-common/app/Traits/Translations.php
+++ b/stubs/inertia-common/app/Traits/Translations.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+
+trait Translations
+{
+    /**
+     * Retrieve all translation keys for the current locale from the PHP and JSON language files.
+     */
+    protected function translations(): array
+    {
+        $locale = App::getLocale();
+
+        return Cache::rememberForever("translations_$locale", function () use ($locale) {
+            $phpTranslations = [];
+            $jsonTranslations = [];
+
+            if (File::exists(base_path("lang/$locale"))) {
+                $phpTranslations = collect(File::allFiles(base_path("lang/$locale")))
+                    ->filter(function ($file) {
+                        return $file->getExtension() === "php";
+                    })->flatMap(function ($file) {
+                        return Arr::dot([$file->getFilenameWithoutExtension() => File::getRequire($file->getRealPath())]);
+                    })->toArray();
+            }
+
+            if (File::exists(base_path("lang/$locale.json"))) {
+                $jsonTranslations = json_decode(File::get(base_path("lang/$locale.json")), true);
+            }
+
+            return array_merge($phpTranslations, $jsonTranslations);
+        });
+    }
+}

--- a/stubs/inertia-react/resources/js/Contexts/Translations.jsx
+++ b/stubs/inertia-react/resources/js/Contexts/Translations.jsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { createContext } from "react";
+import React from 'react';
+import { createContext } from 'react';
 
 export const TranslationsContext = createContext();
 
 export const TranslationsProvider = ({ translations = {}, children }) => {
     if (!translations) {
-        console.warn("Please provide translations to the TranslationsProvider.");
+        console.warn('Please provide translations to the TranslationsProvider.');
     }
 
     // Translate the given message
@@ -22,9 +22,5 @@ export const TranslationsProvider = ({ translations = {}, children }) => {
     // Shorter alias
     const __ = translate;
 
-    return (
-        <TranslationsContext.Provider value={{ translate, __ }}>
-            {children}
-        </TranslationsContext.Provider>
-    );
+    return <TranslationsContext.Provider value={{ translate, __ }}>{children}</TranslationsContext.Provider>;
 };

--- a/stubs/inertia-react/resources/js/Contexts/Translations.jsx
+++ b/stubs/inertia-react/resources/js/Contexts/Translations.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { createContext } from "react";
+
+export const TranslationsContext = createContext();
+
+export const TranslationsProvider = ({ translations = {}, children }) => {
+    if (!translations) {
+        console.warn("Please provide translations to the TranslationsProvider.");
+    }
+
+    // Translate the given message
+    const translate = (key, replace = {}) => {
+        let translation = translations[key] || key;
+
+        Object.keys(replace).forEach((r) => {
+            translation = translation.replace(`:${r}`, replace[r]);
+        });
+
+        return translation;
+    };
+
+    // Shorter alias
+    const __ = translate;
+
+    return (
+        <TranslationsContext.Provider value={{ translate, __ }}>
+            {children}
+        </TranslationsContext.Provider>
+    );
+};

--- a/stubs/inertia-react/resources/js/app.jsx
+++ b/stubs/inertia-react/resources/js/app.jsx
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { TranslationsProvider } from "@/Contexts/Translations.jsx";
+import { TranslationsProvider } from '@/Contexts/Translations.jsx';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
 

--- a/stubs/inertia-react/resources/js/app.jsx
+++ b/stubs/inertia-react/resources/js/app.jsx
@@ -4,6 +4,7 @@ import '../css/app.css';
 import { createRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
+import { TranslationsProvider } from "@/Contexts/Translations.jsx";
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
 
@@ -13,7 +14,11 @@ createInertiaApp({
     setup({ el, App, props }) {
         const root = createRoot(el);
 
-        root.render(<App {...props} />);
+        root.render(
+            <TranslationsProvider translations={props.initialPage.props.translations}>
+                <App {...props} />
+            </TranslationsProvider>
+        );
     },
     progress: {
         color: '#4B5563',

--- a/stubs/inertia-vue/resources/js/Plugins/Translations.js
+++ b/stubs/inertia-vue/resources/js/Plugins/Translations.js
@@ -1,0 +1,28 @@
+export default {
+    install: (app, options = {}) => {
+        if (!options.translations) {
+            console.warn("Please provide translations to the plugin.");
+        }
+
+        const translations = options.translations || {};
+
+        // Translate the given message
+        const translate = (key, replace = {}) => {
+            let translation = translations[key] || key;
+
+            Object.keys(replace).forEach((r) => {
+                translation = translation.replace(`:${r}`, replace[r]);
+            });
+
+            return translation;
+        };
+
+        // Define global properties
+        app.config.globalProperties.$translate = translate;
+        app.config.globalProperties.__ = translate;
+
+        // Provide methods
+        app.provide("translate", { translate });
+        app.provide("__", { translate });
+    },
+};

--- a/stubs/inertia-vue/resources/js/Plugins/Translations.js
+++ b/stubs/inertia-vue/resources/js/Plugins/Translations.js
@@ -1,7 +1,7 @@
 export default {
     install: (app, options = {}) => {
         if (!options.translations) {
-            console.warn("Please provide translations to the plugin.");
+            console.warn('Please provide translations to the plugin.');
         }
 
         const translations = options.translations || {};
@@ -22,7 +22,7 @@ export default {
         app.config.globalProperties.__ = translate;
 
         // Provide methods
-        app.provide("translate", { translate });
-        app.provide("__", { translate });
+        app.provide('translate', { translate });
+        app.provide('__', { translate });
     },
 };

--- a/stubs/inertia-vue/resources/js/app.js
+++ b/stubs/inertia-vue/resources/js/app.js
@@ -5,7 +5,7 @@ import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
-import Translations from "@/Plugins/Translations.js";
+import Translations from '@/Plugins/Translations.js';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
 

--- a/stubs/inertia-vue/resources/js/app.js
+++ b/stubs/inertia-vue/resources/js/app.js
@@ -5,6 +5,7 @@ import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import Translations from "@/Plugins/Translations.js";
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
 
@@ -15,6 +16,9 @@ createInertiaApp({
         return createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue, Ziggy)
+            .use(Translations, {
+                translations: props.initialPage.props.translations,
+            })
             .mount(el);
     },
     progress: {


### PR DESCRIPTION
This pull request adds translation support for Inertia, which is already implemented in the Blade stack.

It provides a **simple and easy way** to use translations in your Inertia application. The Translations trait handles all the translations. It checks if there are any translation files ([PHP and JSON](https://laravel.com/docs/10.x/localization#defining-translation-strings)) available for the current locale and transforms them into an array.  All translations are then cached and forwarded using the Inertia shared data (in the HandleInertiaRequests middleware).

**Vue.js:**
The app.js file, all the translations are retrieved from the shared data and passed (through the options) to the translations plugin. The translations plugin contains the `translate()` method, which requires a `key` parameter and an optional `replace` parameter. The translate method works the same as the Laravel [translate helper](https://laravel.com/docs/10.x/localization#retrieving-translation-strings) function. 

It also defines two global properties: `$translate()` and `__()`, which can be used to get the translated message in your Vue.js components.

Usage:
```
<script setup>
// Import through inject
import {inject} from 'vue'
const {translate} = inject('translate');

const example = translate('Hello world!');
</script>

<template>
    <AuthenticatedLayout>
        <!-- Translate using the global __() method -->
        <h1>{{ __('greeting', {name: 'Jacob'}) }}</h1>

        <!-- Translate using the global translate() method -->
        <p>{{ translate('Welcome on our website!') }}</p>
    </AuthenticatedLayout>
</template>
```

**React:**
In the TranslationsContext the same `translate()` method is available for the whole application. 
In the app.jsx file, all the translations are passed to the TranslationsContext, which wraps around the `<App/>` component. So that it's available for the whole application.

The TranslationsContext also contains two methods: `translate()` and `__()`, which can be used to get the translated message in your React components.

Usage:
```
// Import useContext and the TranslationsContext
import {useContext} from "react";
import {TranslationsContext} from "@/Contexts/Translations.jsx";

export default function Dashboard(props) {
    // Retrieve the __ and translate method
    const { __, translate } = useContext(TranslationsContext);

    return (
        <AuthenticatedLayout
            auth={props.auth}
            errors={props.errors}
            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
        >
            // Translate using the __() method
            <h1>{ __('greeting', {name: 'Jacob'}) }</h1>

            // Translate using the translate() method
            <p>{ translate('Welcome on our website!') }</p>
        </AuthenticatedLayout>
    );
}
```

Please note that after editing your translations, you need to clear the cache with `php artisan cache:clear`.