### PR TITLE
API Stub EnsureEmailIsVerified Middleware: Remove unused function arguments in params

### DIFF
--- a/stubs/api/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/stubs/api/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -14,7 +14,7 @@ class EnsureEmailIsVerified
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string $redirectToRoute = null): Response
+    public function handle(Request $request, Closure $next): Response
     {
         if (! $request->user() ||
             ($request->user() instanceof MustVerifyEmail &&


### PR DESCRIPTION
Remove unused function arguments in params from EnsureEmailIsVerified Middleware in API Stub 

File Path: /breeze/stubs/api/app/Http/Middleware/EnsureEmailIsVerified.php
