### PR TITLE
[1.x] React - fix input focus on update password error

### DIFF
--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
@@ -22,7 +22,7 @@ export default function UpdatePasswordForm({ className }) {
         put(route('password.update'), {
             preserveScroll: true,
             onSuccess: () => reset(),
-            onError: () => {
+            onError: (errors) => {
                 if (errors.password) {
                     reset('password', 'password_confirmation');
                     passwordInput.current.focus();


### PR DESCRIPTION
The React version of the update password form has a minor bug where it doesn't correctly focus the input after a validation error.

The issue is caused by inspecting the `errors` state object when a route error occurs. When the error handler is called, the `errors` state hasn't been updated with the latest errors so it will always be the value from before the form was submitted.

The solution is to check the error object passed to the error handler instead.