### PR TITLE
[1.x] React - Remove unnecessary text input wrapper

### DIFF
--- a/stubs/inertia-react/resources/js/Components/TextInput.jsx
+++ b/stubs/inertia-react/resources/js/Components/TextInput.jsx
@@ -10,16 +10,14 @@ export default forwardRef(function TextInput({ type = 'text', className = '', is
     }, []);
 
     return (
-        <div className="flex flex-col items-start">
-            <input
-                {...props}
-                type={type}
-                className={
-                    'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm ' +
-                    className
-                }
-                ref={input}
-            />
-        </div>
+        <input
+            {...props}
+            type={type}
+            className={
+                'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm ' +
+                className
+            }
+            ref={localRef}
+        />
     );
 });


### PR DESCRIPTION
This PR removes the unnecessary wrapper `<div>` in the `TextInput` component.

It doesn't exist in the other stacks and doesn't seem to do anything. It also makes it harder to position the input in some layouts because the className prop is passed to the nested `<input>`.