### PR TITLE
[1.x] React - Fix potential "undefined" class

### DIFF
--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
@@ -7,7 +7,7 @@ import SecondaryButton from '@/Components/SecondaryButton';
 import TextInput from '@/Components/TextInput';
 import { useForm } from '@inertiajs/react';
 
-export default function DeleteUserForm({ className }) {
+export default function DeleteUserForm({ className = '' }) {
     const [confirmingUserDeletion, setConfirmingUserDeletion] = useState(false);
     const passwordInput = useRef();
 

--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
@@ -6,7 +6,7 @@ import TextInput from '@/Components/TextInput';
 import { useForm } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
 
-export default function UpdatePasswordForm({ className }) {
+export default function UpdatePasswordForm({ className = '' }) {
     const passwordInput = useRef();
     const currentPasswordInput = useRef();
 

--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -5,7 +5,7 @@ import TextInput from '@/Components/TextInput';
 import { Link, useForm, usePage } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
 
-export default function UpdateProfileInformation({ mustVerifyEmail, status, className }) {
+export default function UpdateProfileInformation({ mustVerifyEmail, status, className = '' }) {
     const user = usePage().props.auth.user;
 
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({


### PR DESCRIPTION
Components that destructure the `className` prop need to specify a default empty string. Otherwise, if the consuming component does not provide a `className`, the value will be `undefined`. When the `className` is cast to a string in the template, JavaScript will insert a literal string `"undefined"` as a class name.