### PR TITLE
Update `current_password` rule in ProfileController

### DIFF
--- a/stubs/default/app/Http/Controllers/ProfileController.php
+++ b/stubs/default/app/Http/Controllers/ProfileController.php
@@ -43,7 +43,7 @@ class ProfileController extends Controller
     public function destroy(Request $request): RedirectResponse
     {
         $request->validateWithBag('userDeletion', [
-            'password' => ['required', 'current-password'],
+            'password' => ['required', 'current_password'],
         ]);
 
         $user = $request->user();

--- a/stubs/inertia-common/app/Http/Controllers/ProfileController.php
+++ b/stubs/inertia-common/app/Http/Controllers/ProfileController.php
@@ -46,7 +46,7 @@ class ProfileController extends Controller
     public function destroy(Request $request): RedirectResponse
     {
         $request->validate([
-            'password' => ['required', 'current-password'],
+            'password' => ['required', 'current_password'],
         ]);
 
         $user = $request->user();


### PR DESCRIPTION
This PR aims to standardize the `current-password` rule in ProfileController utilizing the known `current_password` rule name.

While `current-password` still works as expected, the oficially documented rule is `current_password`, and since this files are published to the user application, it makes sense to use the common name.