### PR TITLE
[1.x] Fix Pest test installation for Inertia stack

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -88,7 +88,11 @@ trait InstallsInertiaStacks
             return 1;
         }
 
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/tests/Feature', base_path('tests/Feature'));
+        if ($this->option('pest')) {
+            (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/pest-tests/Feature', base_path('tests/Feature'));
+        } else {
+            (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/tests/Feature', base_path('tests/Feature'));
+        }
 
         // Routes...
         copy(__DIR__.'/../../stubs/inertia-common/routes/web.php', base_path('routes/web.php'));
@@ -248,7 +252,12 @@ trait InstallsInertiaStacks
 
         // Tests...
         $this->installTests();
-        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/tests/Feature', base_path('tests/Feature'));
+
+        if ($this->option('pest')) {
+            (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/pest-tests/Feature', base_path('tests/Feature'));
+        } else {
+            (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/tests/Feature', base_path('tests/Feature'));
+        }
 
         // Routes...
         copy(__DIR__.'/../../stubs/inertia-common/routes/web.php', base_path('routes/web.php'));

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -251,7 +251,9 @@ trait InstallsInertiaStacks
         }
 
         // Tests...
-        $this->installTests();
+        if (! $this->installTests()) {
+            return 1;
+        }
 
         if ($this->option('pest')) {
             (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia-common/pest-tests/Feature', base_path('tests/Feature'));


### PR DESCRIPTION
This PR fixes an issue in the Breezes installer where it would always install the PHPUnit version of `ProfileTest` and `PasswordUpdateTest` regardless of whether the `--pest` option was specified.

Thanks go to [this tweet](https://twitter.com/swazlo/status/1639623260852850689) for raising the issue.

I've also added a missing failure handler to the React stack installer for when Pest fails to be installed, which I noticed was present in the other stack installers.