### PR TITLE
Add Test Cases for Negative Scenarios in User Registration

### DIFF
--- a/stubs/default/pest-tests/Feature/Auth/RegistrationTest.php
+++ b/stubs/default/pest-tests/Feature/Auth/RegistrationTest.php
@@ -19,3 +19,23 @@ test('new users can register', function () {
     $this->assertAuthenticated();
     $response->assertRedirect(RouteServiceProvider::HOME);
 });
+
+test('test new users cant register when password length less', function () {
+    $response = $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => '111',
+        'password_confirmation' => '111',
+    ]);
+    $response->assertSessionHasErrors(['password']);
+});
+
+test('test new users cant register when password is not same confirm', function () {
+    $response = $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => '0123456789',
+        'password_confirmation' => '1111111111',
+    ]);
+    $response->assertSessionHasErrors(['password']);
+});

--- a/stubs/default/pest-tests/Feature/Auth/RegistrationTest.php
+++ b/stubs/default/pest-tests/Feature/Auth/RegistrationTest.php
@@ -20,7 +20,7 @@ test('new users can register', function () {
     $response->assertRedirect(RouteServiceProvider::HOME);
 });
 
-test('test new users cant register when password length less', function () {
+test('new users cant register when password length less', function () {
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',
@@ -30,7 +30,7 @@ test('test new users cant register when password length less', function () {
     $response->assertSessionHasErrors(['password']);
 });
 
-test('test new users cant register when password is not same confirm', function () {
+test('new users cant register when password is not same confirm', function () {
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',

--- a/stubs/default/tests/Feature/Auth/RegistrationTest.php
+++ b/stubs/default/tests/Feature/Auth/RegistrationTest.php
@@ -29,4 +29,26 @@ class RegistrationTest extends TestCase
         $this->assertAuthenticated();
         $response->assertRedirect(RouteServiceProvider::HOME);
     }
+
+    public function test_new_users_cant_register_when_password_length_less(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => '111',
+            'password_confirmation' => '111',
+        ]);
+        $response->assertSessionHasErrors(['password']);
+    }
+
+    public function test_new_users_cant_register_when_password_is_not_same_confirm(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => '0123456789',
+            'password_confirmation' => '1111111111',
+        ]);
+        $response->assertSessionHasErrors(['password']);
+    }
 }


### PR DESCRIPTION
# Overview

Added validation for invalid passwords entered during user registration in the `test` and `pest-tests`.
The added patterns are:

- When the number of characters is less than the default 8 digits.
- When different passwords are entered for registration and confirmation.

# Reason

- So far, only positive test cases have been present in the user registration test, and I thought that negative test cases should also be tested.
- In the future development process, negative test cases may be inadvertently broken. To detect it in such cases.

That's all.
Thank you for your attention.
