### PR TITLE
Register page linked with the login page

### DIFF
--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -44,4 +44,12 @@
             </x-primary-button>
         </div>
     </form>
+    <br>
+    <hr>
+    <br>
+    <div class="text-center">
+        <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('register') }}">
+            {{ __('Create a new Account') }}
+        </a>
+    </div>
 </x-guest-layout>


### PR DESCRIPTION
I noticed that the Laravel Breeze login page did not have a registration link, so I added it myself. As Laravel is such an important framework, I believe it's essential to make sure that everything is up to scratch. I have pushed the code to the Git repository and I am hoping that it will be accepted. This is my second attempt to connect with Laravel using my skills and knowledge, and I am crossing my fingers for the best outcome. Overall, it has been an exciting experience and I look forward to continuing to contribute to the community.
