### PR TITLE
[1.x] Remove unnecessary union type on Vue refs

### DIFF
--- a/stubs/inertia-vue-ts/resources/js/Components/TextInput.vue
+++ b/stubs/inertia-vue-ts/resources/js/Components/TextInput.vue
@@ -7,7 +7,7 @@ defineProps<{
 
 defineEmits(['update:modelValue']);
 
-const input = ref<HTMLInputElement | null>(null);
+const input = ref<HTMLInputElement>();
 
 onMounted(() => {
     if (input.value?.hasAttribute('autofocus')) {

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -9,7 +9,7 @@ import { useForm } from '@inertiajs/vue3';
 import { nextTick, ref } from 'vue';
 
 const confirmingUserDeletion = ref(false);
-const passwordInput = ref<HTMLInputElement | null>(null);
+const passwordInput = ref<HTMLInputElement>();
 
 const form = useForm({
     password: '',

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
@@ -6,8 +6,8 @@ import TextInput from '@/Components/TextInput.vue';
 import { useForm } from '@inertiajs/vue3';
 import { ref } from 'vue';
 
-const passwordInput = ref<HTMLInputElement | null>(null);
-const currentPasswordInput = ref<HTMLInputElement | null>(null);
+const passwordInput = ref<HTMLInputElement>();
+const currentPasswordInput = ref<HTMLInputElement>();
 
 const form = useForm({
     current_password: '',


### PR DESCRIPTION
From the Vue.js docs: https://vuejs.org/guide/typescript/composition-api.html#typing-ref

> If you specify a generic type argument but omit the initial value, the resulting type will be a union type that includes undefined:

> ```typescript
> // inferred type: Ref<number | undefined>
> const n = ref<number>()
> ```