### PR TITLE
Fix return has no type specified in iterable type array

### DIFF
--- a/stubs/default/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/default/app/Http/Requests/Auth/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<string>|string>
      */
     public function rules(): array
     {

--- a/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
+++ b/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
@@ -11,7 +11,7 @@ class ProfileUpdateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<string>|string>
      */
     public function rules(): array
     {


### PR DESCRIPTION
When testing with phpstan, errors appear when running ./vendor/bin/phpstan analysis
in projects with the breeze installed.