### PR TITLE
[1.x] Remove implicit form method calls

### DIFF
--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -12,7 +12,9 @@ const form = useForm({
 
 const submit = () => {
     form.post(route('password.confirm'), {
-        onFinish: () => form.reset(),
+        onFinish: () => {
+            form.reset();
+        },
     });
 };
 </script>

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/Login.vue
@@ -20,7 +20,9 @@ const form = useForm({
 
 const submit = () => {
     form.post(route('login'), {
-        onFinish: () => form.reset('password'),
+        onFinish: () => {
+            form.reset('password');
+        },
     });
 };
 </script>

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/Register.vue
@@ -15,7 +15,9 @@ const form = useForm({
 
 const submit = () => {
     form.post(route('register'), {
-        onFinish: () => form.reset('password', 'password_confirmation'),
+        onFinish: () => {
+            form.reset('password', 'password_confirmation');
+        },
     });
 };
 </script>

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/ResetPassword.vue
@@ -20,7 +20,9 @@ const form = useForm({
 
 const submit = () => {
     form.post(route('password.store'), {
-        onFinish: () => form.reset('password', 'password_confirmation'),
+        onFinish: () => {
+            form.reset('password', 'password_confirmation');
+        },
     });
 };
 </script>

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -26,7 +26,9 @@ const deleteUser = () => {
         preserveScroll: true,
         onSuccess: () => closeModal(),
         onError: () => passwordInput.value?.focus(),
-        onFinish: () => form.reset(),
+        onFinish: () => {
+            form.reset();
+        },
     });
 };
 

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
@@ -18,7 +18,9 @@ const form = useForm({
 const updatePassword = () => {
     form.put(route('password.update'), {
         preserveScroll: true,
-        onSuccess: () => form.reset(),
+        onSuccess: () => {
+            form.reset();
+        },
         onError: () => {
             if (form.errors.password) {
                 form.reset('password', 'password_confirmation');


### PR DESCRIPTION
Inertia Typescript doesn't allow it to call form methods implicitly on form event callbacks.

This is not allowed:
```ts
form.post(route('password.confirm'), {
    onFinish: () => form.reset(),
});
```
(Typescript) error:
`Argument type {} & InertiaFormProps{} is not assignable to parameter type Partial<VisitOptions> | undefined`

Wrapped it with curly brackets:
```ts
form.post(route('password.confirm'), {
    onFinish: () => {
        form.reset();
    },
});
```

More info is here: https://stackoverflow.com/q/76323706/17666912 
