### PR TITLE
Auth controller regenerate session called twice

### DIFF
--- a/stubs/default/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/default/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -27,8 +27,6 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
-        $request->session()->regenerate();
-
         return redirect()->intended(RouteServiceProvider::HOME);
     }
 


### PR DESCRIPTION
It looks like the Laravel framework is already regenerating the session automatically when logging in.

Here's the flow:
- AuthenticatedSessionController@store
    - `$request->authenticate()`
- LoginRequest@authenticate
    - `$this->attemptLogin()`
- Illuminate\Auth\SessionGuard@attempt
    - `$this->login($user, $remember)`
    - `$this->updateSession($user->getAuthIdentifier())`
    - `$this->session->migrate(true)`

So we don't need to manually call `$request->session()->regenerate()` (which then calls `$this->session->migrate()`).

We probably still need to manually call `$request->session()->regenerateToken()` though. I'll amend the PR based on your feedback.