### PR TITLE
back button added into forget-password blade file to go back to login…

### DIFF
--- a/stubs/default/resources/views/auth/forgot-password.blade.php
+++ b/stubs/default/resources/views/auth/forgot-password.blade.php
@@ -1,4 +1,10 @@
 <x-guest-layout>
+
+    <!-- Back Button -->
+    <div class="mb-4 text-sm text-gray-600">
+        <x-back-button></x-back-button>
+    </div>
+    
     <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
         {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
     </div>

--- a/stubs/default/resources/views/components/back-button.blade.php
+++ b/stubs/default/resources/views/components/back-button.blade.php
@@ -1,0 +1,3 @@
+<x-primary-button onclick="window.history.back()">
+    &#8592;
+</x-primary-button>


### PR DESCRIPTION
Back button added into forget-password screen to go back to login screen easily rather than going back from browser button or first go to home screen by clicking on logo and then click on login link. 