### PR TITLE
destructure props

### DIFF
--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/ResetPassword.vue
@@ -5,15 +5,18 @@ import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
 import { Head, useForm } from '@inertiajs/vue3';
+import { toRefs } from 'vue';
 
 const props = defineProps<{
     email: string;
     token: string;
 }>();
 
+const { email, token } = toRefs(props);
+    
 const form = useForm({
-    token: props.token,
-    email: props.email,
+    token: token.value,
+    email: email.value,
     password: '',
     password_confirmation: '',
 });


### PR DESCRIPTION
To avoid error **typescript ESLint: Getting a value from the `props` in root scope of `<script setup>`** we need to destructure the props with toRefs()

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
