### PR TITLE
[1.x] Pest detection

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -73,8 +73,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
         $stubStack = $this->argument('stack') === 'api' ? 'api' : 'default';
 
-        if ($this->option('pest')) {
-            $this->removeComposerPackages(['phpunit/phpunit'], true);
+        if ($this->option('pest') || $this->isUsingPest()) {
+            if ($this->hasComposerPackage('phpunit/phpunit')) {
+                $this->removeComposerPackages(['phpunit/phpunit'], true);
+            }
 
             if (! $this->requireComposerPackages(['pestphp/pest:^2.0', 'pestphp/pest-plugin-laravel:^2.0'], true)) {
                 return false;
@@ -174,6 +176,20 @@ class InstallCommand extends Command implements PromptsForMissingInput
             ->run(function ($type, $output) {
                 $this->output->write($output);
             }) === 0;
+    }
+
+    /**
+     * Determine if the given Composer Package is installed.
+     *
+     * @param  string  $package
+     * @return bool
+     */
+    protected function hasComposerPackage($package)
+    {
+        $packages = json_decode(file_get_contents(base_path('composer.json')), true);
+
+        return array_key_exists($package, $packages['require'] ?? [])
+            || array_key_exists($package, $packages['require-dev'] ?? []);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -330,6 +330,17 @@ class InstallCommand extends Command implements PromptsForMissingInput
         $input->setOption('pest', select(
             label: 'Which testing framework do you prefer?',
             options: ['PHPUnit', 'Pest'],
+            default: $this->isUsingPest() ? 'Pest' : 'PHPUnit',
         ) === 'Pest');
+    }
+
+    /**
+     * Determine whether the project is already using Pest.
+     *
+     * @return bool
+     */
+    protected function isUsingPest()
+    {
+        return file_exists(base_path('tests/Pest.php'));
     }
 }


### PR DESCRIPTION
This PR updates the standalone Breeze installer to default to Pest when it is already installed, either via the Laravel installer or installed manually.

When running `php artisan breeze:install` with no arguments, the testing framework prompt will still be displayed, but defaulting to Pest when installed:

![image](https://github.com/laravel/breeze/assets/4977161/5c4616e1-6753-4a98-ad35-2f8a50bc33af)

When passing arguments to the installer (e.g. `php artisan breeze:install blade`) the prompt does not appear. Currently, it will install PHPUnit tests unless the `--pest` flag was passed. With this change, it will automatically install Pest tests when appropriate.
