### PR TITLE
Fix 404 error on password reset link received in emails

### DIFF
--- a/stubs/api/app/Providers/AuthServiceProvider.php
+++ b/stubs/api/app/Providers/AuthServiceProvider.php
@@ -24,7 +24,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {
-            return route('password.reset', ['token'=>$token]) . "?email={$notifiable->getEmailForPasswordReset()}";
+            return route('password.reset', ['token' => $token])."?email={$notifiable->getEmailForPasswordReset()}";
         });
 
         //

--- a/stubs/api/app/Providers/AuthServiceProvider.php
+++ b/stubs/api/app/Providers/AuthServiceProvider.php
@@ -24,7 +24,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {
-            return config('app.frontend_url')."/password-reset/$token?email={$notifiable->getEmailForPasswordReset()}";
+            return route('password.reset', ['token'=>$token]) . "?email={$notifiable->getEmailForPasswordReset()}";
         });
 
         //


### PR DESCRIPTION
Password reset link was wrong and it would lead to 404 error.

the link sent to email was this: 
http://localhost:3000/password-reset/{TOKEN}?email={EMAIL}

and it should have been this:
http://localhost:3000/reset-password/{TOKEN}?email={EMAIL}

by using named route we make sure the correct link is sent and this problem doesn't happen again.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
