### PR TITLE
[1.x] Replace `array_merge` with spread operator in `HandleInertiaRequests`

### DIFF
--- a/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,7 +35,7 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
-            'ziggy' => fn() => [
+            'ziggy' => fn () => [
                 ...(new Ziggy)->toArray(),
                 'location' => $request->url(),
             ],

--- a/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
@@ -30,15 +30,15 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
-        return array_merge(parent::share($request), [
+        return [
+            ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
             ],
-            'ziggy' => function () use ($request) {
-                return array_merge((new Ziggy)->toArray(), [
-                    'location' => $request->url(),
-                ]);
-            },
-        ]);
+            'ziggy' => fn() => [
+                ...(new Ziggy)->toArray(),
+                'location' => $request->url(),
+            ],
+        ];
     }
 }


### PR DESCRIPTION
IMO, this change makes it more readable. Performance should be the same or better.