### PR TITLE
[1.x] Add missing tests for VerifyEmailController to fix up coverage

### DIFF
--- a/stubs/default/pest-tests/Feature/Auth/EmailVerificationTest.php
+++ b/stubs/default/pest-tests/Feature/Auth/EmailVerificationTest.php
@@ -52,7 +52,7 @@ test('email is not verified with invalid hash', function () {
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });
 
-test('already verified users will not cause event to dispatch', function() {
+test('already verified users will not cause event to dispatch', function () {
     $user = User::factory()->create();
 
     Event::fake();
@@ -66,5 +66,5 @@ test('already verified users will not cause event to dispatch', function() {
     Event::assertNotDispatched(Verified::class);
 
     $response = $this->actingAs($user)->get($verificationUrl);
-    $response->assertRedirect(RouteServiceProvider::HOME . '?verified=1');
+    $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
 });

--- a/stubs/default/tests/Feature/Auth/EmailVerificationTest.php
+++ b/stubs/default/tests/Feature/Auth/EmailVerificationTest.php
@@ -79,6 +79,5 @@ class EmailVerificationTest extends TestCase
 
         Event::assertNotDispatched(Verified::class);
         $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
-
     }
 }


### PR DESCRIPTION
Hi there,

This pull request add the missing tests to the VerifyEmailController, so that the test-coverage reaches 100%. It will be timesaving for others to have this starter kit reach closer to 100% test-coverage.