### PR TITLE
sending the verification email to the user before redirecting to the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#8155BA",
+        "activityBar.foreground": "#281C2D",
+        "activityBar.inactiveForeground": "#252525",
+        "activityBar.activeBorder": "#7eaa45",
+        "activityBar.activeBackground": "#695E93",
+        "activityBar.border": "#695E93",
+        "titleBar.activeBackground": "#8155BA",
+        "titleBar.activeForeground": "#281C2D",
+        "titleBar.inactiveBackground": "#85739c",
+        "titleBar.inactiveForeground": "#252525",
+        "titleBar.border": "#695E93",
+        "statusBar.background": "#8155BA",
+        "statusBar.foreground": "#281C2D",
+        "statusBar.border": "#695E93"
+    }
+}

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -19,7 +19,6 @@ class EmailVerificationPromptController extends Controller
         {
             return redirect()->intended(RouteServiceProvider::HOME); 
         }
-
         $request->user()->sendEmailVerificationNotification();
         return view('auth.verify-email');
     }

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -15,11 +15,11 @@ class EmailVerificationPromptController extends Controller
      */
     public function __invoke(Request $request): RedirectResponse|View
     {
-        if($request->user()->hasVerifiedEmail())
-        {
-            return redirect()->intended(RouteServiceProvider::HOME); 
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect()->intended(RouteServiceProvider::HOME);
         }
         $request->user()->sendEmailVerificationNotification();
+
         return view('auth.verify-email');
     }
 }

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -15,8 +15,12 @@ class EmailVerificationPromptController extends Controller
      */
     public function __invoke(Request $request): RedirectResponse|View
     {
-        return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(RouteServiceProvider::HOME)
-                    : view('auth.verify-email');
+        if($request->user()->hasVerifiedEmail())
+        {
+            return redirect()->intended(RouteServiceProvider::HOME); 
+        }
+
+        $request->user()->sendEmailVerificationNotification();
+        return view('auth.verify-email');
     }
 }


### PR DESCRIPTION
The bug is that when redirecting the user to verify-email.blade.php view we don't send a verification email to him, but we display a button with the text RESEND VERIFICATION EMAIL which means that the email was already sent but it's not in EmailVerificationPromptController we just check email verification and redirect the user to verify-email.blade.php without sending the verification email.