### PR TITLE
fix: :bug: bring navigation links on top of other elements

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Welcome.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Welcome.tsx
@@ -6,7 +6,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }: PageProps<
         <>
             <Head title="Welcome" />
             <div className="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
-                <div className="sm:fixed sm:top-0 sm:right-0 p-6 text-right">
+                <div className="sm:fixed sm:top-0 sm:right-0 sm:z-10 p-6 text-right">
                     {auth.user ? (
                         <Link
                             href={route('dashboard')}

--- a/stubs/inertia-react/resources/js/Pages/Welcome.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Welcome.jsx
@@ -5,7 +5,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
         <>
             <Head title="Welcome" />
             <div className="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
-                <div className="sm:fixed sm:top-0 sm:right-0 p-6 text-right">
+                <div className="sm:fixed sm:top-0 sm:right-0 sm:z-10 p-6 text-right">
                     {auth.user ? (
                         <Link
                             href={route('dashboard')}

--- a/stubs/inertia-vue-ts/resources/js/Pages/Welcome.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Welcome.vue
@@ -15,7 +15,7 @@ defineProps<{
     <div
         class="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white"
     >
-        <div v-if="canLogin" class="sm:fixed sm:top-0 sm:right-0 p-6 text-right">
+        <div v-if="canLogin" class="sm:fixed sm:top-0 sm:right-0 sm:z-10 p-6 text-right">
             <Link
                 v-if="$page.props.auth.user"
                 :href="route('dashboard')"

--- a/stubs/inertia-vue/resources/js/Pages/Welcome.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Welcome.vue
@@ -25,7 +25,7 @@ defineProps({
     <div
         class="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white"
     >
-        <div v-if="canLogin" class="sm:fixed sm:top-0 sm:right-0 p-6 text-right">
+        <div v-if="canLogin" class="sm:fixed sm:top-0 sm:right-0 sm:z-10 p-6 text-right">
             <Link
                 v-if="$page.props.auth.user"
                 :href="route('dashboard')"

--- a/stubs/livewire/resources/views/livewire/welcome/navigation.blade.php
+++ b/stubs/livewire/resources/views/livewire/welcome/navigation.blade.php
@@ -1,4 +1,4 @@
-<div class="sm:fixed sm:top-0 sm:right-0 p-6 text-right z-10">
+<div class="sm:fixed sm:top-0 sm:right-0 sm:z-10 p-6 text-right z-10">
     @auth
         <a href="{{ url('/dashboard') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500" wire:navigate>Dashboard</a>
     @else


### PR DESCRIPTION
## The Problem
When you install a new Laravel Breeze project, you'll notice that on desktop screens, the navigation links can sometimes get buried beneath other content, like cards.

## Examples:
![laravel-breeze-nav-bug](https://github.com/laravel/breeze/assets/94674993/721751b4-d01e-4696-b8f4-1e77abdc80f2)

<img width="707" alt="Screenshot of Breeze's navlinks issue" src="https://github.com/laravel/breeze/assets/94674993/05a121b5-e8f1-4652-b4a1-4b6d7c8cec0e">

## The Solution
This change is to ensure that the sticky navbar in Laravel Breeze always stays on top of the page's elements which is the expected behavior of any navbar.

## After
![laravel-breeze-after-fixing-navlinks](https://github.com/laravel/breeze/assets/94674993/f22f727c-1a1a-4337-984a-bda2295b6605)
