### PR TITLE
Removed PHPStan errors which would show up after installing the breeze package.

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/api/app/Http/Controllers/Auth/NewPasswordController.php
@@ -30,11 +30,16 @@ class NewPasswordController extends Controller
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
+
+        /** @var string $password */
+        $password = $request->input('password');
+
+        /** @var ?string $status */
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user) use ($request) {
+            function ($user) use ($password) {
                 $user->forceFill([
-                    'password' => Hash::make($request->password),
+                    'password' => Hash::make($password),
                     'remember_token' => Str::random(60),
                 ])->save();
 

--- a/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -26,10 +26,13 @@ class RegisteredUserController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        /** @var string $password */
+        $password = $request->password;
+
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'password' => Hash::make($password),
         ]);
 
         event(new Registered($user));

--- a/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,16 +15,22 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
-        if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(
-                config('app.frontend_url').RouteServiceProvider::HOME.'?verified=1'
-            );
+        $user = $request->user();
+
+        if ($user !== null && $user->hasVerifiedEmail()) {
+            return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');
         }
 
-        if ($request->user()->markEmailAsVerified()) {
-            event(new Verified($request->user()));
+        if ($user !== null && $user->markEmailAsVerified()) {
+            /**
+             * The next line shows a PHPStan error:
+             * "Verified expects MustVerifyEmail, User given."
+             * This error is being ignored, but it will also go away when extending the User class with the MustVerifyEmail interface,
+             * which you can to do implement mandatory E-Mail verification.
+             */
+            /** @phpstan-ignore-next-line */
+            event(new Verified($user));
         }
-
         return redirect()->intended(
             config('app.frontend_url').RouteServiceProvider::HOME.'?verified=1'
         );

--- a/stubs/api/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/api/app/Http/Requests/Auth/LoginRequest.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Requests\Auth;
 
+use Closure;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class LoginRequest extends FormRequest
@@ -22,7 +24,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<string|Rule|Closure>|string>
      */
     public function rules(): array
     {
@@ -80,6 +82,9 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->input('email')).'|'.$this->ip());
+        /** @var string $email */
+        $email = $this->input('email');
+
+        return Str::transliterate(Str::lower($email).'|'.$this->ip());
     }
 }

--- a/stubs/default/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -26,7 +26,7 @@ class ConfirmablePasswordController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if (! Auth::guard('web')->validate([
-            'email' => $request->user()->email,
+            'email' => $request->user()?->email,
             'password' => $request->password,
         ])) {
             throw ValidationException::withMessages([

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -15,7 +15,7 @@ class EmailVerificationPromptController extends Controller
      */
     public function __invoke(Request $request): RedirectResponse|View
     {
-        return $request->user()->hasVerifiedEmail()
+        return $request->user()?->hasVerifiedEmail()
                     ? redirect()->intended(RouteServiceProvider::HOME)
                     : view('auth.verify-email');
     }

--- a/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
@@ -38,11 +38,15 @@ class NewPasswordController extends Controller
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
+        /** @var string $password */
+        $password = $request->input('password');
+
+        /** @var ?string $status */
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user) use ($request) {
+            function ($user) use ($password) {
                 $user->forceFill([
-                    'password' => Hash::make($request->password),
+                    'password' => Hash::make($password),
                     'remember_token' => Str::random(60),
                 ])->save();
 

--- a/stubs/default/app/Http/Controllers/Auth/PasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/PasswordController.php
@@ -20,7 +20,7 @@ class PasswordController extends Controller
             'password' => ['required', Password::defaults(), 'confirmed'],
         ]);
 
-        $request->user()->update([
+        $request->user()?->update([
             'password' => Hash::make($validated['password']),
         ]);
 

--- a/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -36,12 +36,15 @@ class RegisteredUserController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        /** @var string $password */
+        $password = $request->password;
+
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'password' => Hash::make($password),
         ]);
-
+        
         event(new Registered($user));
 
         Auth::login($user);

--- a/stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,12 +15,21 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
-        if ($request->user()->hasVerifiedEmail()) {
+        $user = $request->user();
+
+        if ($user !== null && $user->hasVerifiedEmail()) {
             return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');
         }
 
-        if ($request->user()->markEmailAsVerified()) {
-            event(new Verified($request->user()));
+        if ($user !== null && $user->markEmailAsVerified()) {
+            /**
+             * The next line shows a PHPStan error:
+             * "Verified expects MustVerifyEmail, User given."
+             * This error is being ignored, but it will also go away when extending the User class with the MustVerifyEmail interface,
+             * which you can to do implement mandatory E-Mail verification.
+             */
+            /** @phpstan-ignore-next-line */
+            event(new Verified($user));
         }
 
         return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');

--- a/stubs/default/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/default/app/Http/Requests/Auth/LoginRequest.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Requests\Auth;
 
+use Closure;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class LoginRequest extends FormRequest
@@ -22,7 +24,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<string|Rule|Closure>|string>
      */
     public function rules(): array
     {
@@ -80,6 +82,9 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->input('email')).'|'.$this->ip());
+        /** @var string $email */
+        $email = $this->input('email');
+
+        return Str::transliterate(Str::lower($email).'|'.$this->ip());
     }
 }

--- a/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
+++ b/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\User;
+use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -11,13 +12,13 @@ class ProfileUpdateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<string|Rule|Closure>|string>
      */
     public function rules(): array
     {
         return [
             'name' => ['string', 'max:255'],
-            'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()?->id)],
         ];
     }
 }

--- a/stubs/inertia-common/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -27,7 +27,7 @@ class ConfirmablePasswordController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if (! Auth::guard('web')->validate([
-            'email' => $request->user()->email,
+            'email' => $request->user()?->email,
             'password' => $request->password,
         ])) {
             throw ValidationException::withMessages([

--- a/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -14,11 +14,11 @@ class EmailVerificationNotificationController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        if ($request->user()->hasVerifiedEmail()) {
+        if ($request->user()?->hasVerifiedEmail()) {
             return redirect()->intended(RouteServiceProvider::HOME);
         }
 
-        $request->user()->sendEmailVerificationNotification();
+        $request->user()?->sendEmailVerificationNotification();
 
         return back()->with('status', 'verification-link-sent');
     }

--- a/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -16,8 +16,8 @@ class EmailVerificationPromptController extends Controller
      */
     public function __invoke(Request $request): RedirectResponse|Response
     {
-        return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(RouteServiceProvider::HOME)
-                    : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
+        return $request->user()?->hasVerifiedEmail()
+            ? redirect()->intended(RouteServiceProvider::HOME)
+            : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
     }
 }

--- a/stubs/inertia-common/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/NewPasswordController.php
@@ -43,11 +43,16 @@ class NewPasswordController extends Controller
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
+        
+        /** @var string $password */
+        $password = $request->input('password');
+
+        /** @var ?string $status */
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user) use ($request) {
+            function ($user) use ($password) {
                 $user->forceFill([
-                    'password' => Hash::make($request->password),
+                    'password' => Hash::make($password),
                     'remember_token' => Str::random(60),
                 ])->save();
 

--- a/stubs/inertia-common/app/Http/Controllers/Auth/PasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/PasswordController.php
@@ -20,7 +20,7 @@ class PasswordController extends Controller
             'password' => ['required', Password::defaults(), 'confirmed'],
         ]);
 
-        $request->user()->update([
+        $request->user()?->update([
             'password' => Hash::make($validated['password']),
         ]);
 

--- a/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -37,10 +37,13 @@ class RegisteredUserController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        /** @var string $password */
+        $password = $request->password;
+
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'password' => Hash::make($password),
         ]);
 
         event(new Registered($user));

--- a/stubs/inertia-common/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,12 +15,21 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
-        if ($request->user()->hasVerifiedEmail()) {
+        $user = $request->user();
+
+        if ($user !== null && $user->hasVerifiedEmail()) {
             return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');
         }
 
-        if ($request->user()->markEmailAsVerified()) {
-            event(new Verified($request->user()));
+        if ($user !== null && $user->markEmailAsVerified()) {
+            /**
+             * The next line shows a PHPStan error:
+             * "Verified expects MustVerifyEmail, User given."
+             * This error is being ignored, but it will also go away when extending the User class with the MustVerifyEmail interface,
+             * which you can to do implement mandatory E-Mail verification.
+             */
+            /** @phpstan-ignore-next-line */
+            event(new Verified($user));
         }
 
         return redirect()->intended(RouteServiceProvider::HOME.'?verified=1');

--- a/stubs/inertia-common/app/Http/Controllers/ProfileController.php
+++ b/stubs/inertia-common/app/Http/Controllers/ProfileController.php
@@ -29,13 +29,17 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
-
-        if ($request->user()->isDirty('email')) {
-            $request->user()->email_verified_at = null;
+        $user = $request->user();
+        $validated = $request->validated();
+        if (is_array($validated)) {
+            $user?->fill($validated);
         }
 
-        $request->user()->save();
+        if ($user?->isDirty('email')) {
+            $user->email_verified_at = null;
+        }
+
+        $user?->save();
 
         return Redirect::route('profile.edit');
     }
@@ -53,7 +57,7 @@ class ProfileController extends Controller
 
         Auth::logout();
 
-        $user->delete();
+        $user?->delete();
 
         $request->session()->invalidate();
         $request->session()->regenerateToken();


### PR DESCRIPTION
I've recently started multiple projects in a row, and as always i instantly download Larastan and set the Level to 9.
When using the breeze package, i have to manually go through all the files and fix the PHPStan errors myself.

This PR fixes this issue and removes the PHPStan errors. I think this will benefit many developers that also use PHPStan/Larastan by default, including myself.

If i made any mistakes in the code / assumed the wrong types or anything else, tell me and I will gladly iterate over this PR and correct the mistakes.