### PR TITLE
Fix missing class import

### DIFF
--- a/stubs/livewire/resources/views/livewire/pages/auth/verify-email.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/verify-email.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Providers\RouteServiceProvider;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 


### PR DESCRIPTION
Added class import to prevent `Class "RouteServiceProvider" not found` error.

![missing_import](https://github.com/laravel/breeze/assets/471334/edd57cf2-5474-4191-8ef4-e3b88a0c0dc4)
