### PR TITLE
[1.x] Adds `lowercase` validation rule to user's `email` field

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -22,7 +22,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -32,7 +32,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
+++ b/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
@@ -16,8 +16,8 @@ class ProfileUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['string', 'max:255'],
-            'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
         ];
     }
 }

--- a/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -33,7 +33,7 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:'.User::class,
+            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/register.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/register.blade.php
@@ -20,7 +20,7 @@ state([
 
 rules([
     'name' => ['required', 'string', 'max:255'],
-    'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+    'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
     'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
 ]);
 

--- a/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -17,7 +17,7 @@ $updateProfileInformation = function () {
 
     $validated = $this->validate([
         'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
+        'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
     ]);
 
     $user->fill($validated);

--- a/stubs/livewire/resources/views/livewire/pages/auth/register.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/register.blade.php
@@ -22,7 +22,7 @@ new #[Layout('layouts.guest')] class extends Component
     {
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -23,7 +23,7 @@ new class extends Component
 
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
         ]);
 
         $user->fill($validated);


### PR DESCRIPTION
This pull request ensures that the given user email is lowercase.

Tests are failing due: https://github.com/laravel/breeze/pull/320.