### PR TITLE
[1.x] Don't hide options

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -322,7 +322,8 @@ class InstallCommand extends Command implements PromptsForMissingInput
                     'react' => 'React with Inertia',
                     'vue' => 'Vue with Inertia',
                     'api' => 'API only',
-                ]
+                ],
+                scroll: 6,
             ),
         ];
     }


### PR DESCRIPTION
With the addition of the Livewire stacks, we now have more options that we do height in the prompts select viewport.

This is a very finite list and it feels weird to hide the one option. Proposing we expand it to show all available options.

## Before

<img width="708" alt="Screenshot 2023-10-20 at 12 44 55 pm" src="https://github.com/laravel/breeze/assets/24803032/e07aea16-1382-43bb-aff4-412af3293655">

## After

<img width="699" alt="Screenshot 2023-10-20 at 12 45 15 pm" src="https://github.com/laravel/breeze/assets/24803032/7cbdf44a-01bf-41b6-9f55-d34b7caf240a">
