### PR TITLE
Fixed Larastan Errors: Return type for rules() methods

### DIFF
--- a/stubs/api/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/api/app/Http/Requests/Auth/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|string[]|string>
      */
     public function rules(): array
     {

--- a/stubs/default/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/default/app/Http/Requests/Auth/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|string[]|string>
      */
     public function rules(): array
     {

--- a/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
+++ b/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
@@ -11,7 +11,7 @@ class ProfileUpdateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|string[]|string>
      */
     public function rules(): array
     {


### PR DESCRIPTION
While analyzing the codebase with Larastan, I encountered the following errors:

 ./vendor/bin/phpstan analyse --memory-limit=2G
 ...
  Line   Http/Requests/Auth/LoginRequest.php                                                          
  :27    Method App\Http\Requests\Auth\LoginRequest::rules() return type has no value type specified  
         in iterable type array.                                                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type    

  Line   Http/Requests/ProfileUpdateRequest.php                                                     
  :16    Method App\Http\Requests\ProfileUpdateRequest::rules() return type has no value type       
         specified in iterable type array.                                                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type  
 ...

To address these issues, I've made modifications to the return type of the `rules()` methods. Specifically, I've changed the `array` to `string[]`. With this adjustment, the aforementioned Larastan errors are resolved.
