### PR TITLE
fix: Livewire 'remember me' flow for login doesn't remember

### DIFF
--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/login.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/login.blade.php
@@ -38,7 +38,7 @@ $login = function () {
         ]);
     }
 
-    if (! auth()->attempt($this->only(['email', 'password'], $this->remember))) {
+    if (! auth()->attempt($this->only(['email', 'password']), $this->remember)) {
         RateLimiter::hit($throttleKey);
 
         throw ValidationException::withMessages([

--- a/stubs/livewire/resources/views/livewire/pages/auth/login.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/login.blade.php
@@ -26,7 +26,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         $this->ensureIsNotRateLimited();
 
-        if (! auth()->attempt($this->only(['email', 'password'], $this->remember))) {
+        if (! auth()->attempt($this->only(['email', 'password']), $this->remember)) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([


### PR DESCRIPTION
**Problem**:
After creating a new Laravel project with the Breeze Livewire starter kit, I noticed my `remember_token` would never be stored, meaning you'd never stay logged in.

After debugging it seems that for this specific flavour of templates there is a typo in the `login.blade.php`. The `$this->only` function in the call to `auth()->attempt()` get's closed after `$this->remember` instead of before, which means it's filtered out.