### PR TITLE
refactor: remove unused import

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Components/Modal.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Modal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, PropsWithChildren, ReactNode } from 'react';
+import { Fragment, PropsWithChildren } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 
 export default function Modal({


### PR DESCRIPTION
-  'ReactNode' is defined but never used  