### PR TITLE
Change Livewire Rule Attribute to Validate Attribute

### DIFF
--- a/stubs/livewire-common/app/Livewire/Forms/LoginForm.php
+++ b/stubs/livewire-common/app/Livewire/Forms/LoginForm.php
@@ -7,18 +7,18 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Form;
 
 class LoginForm extends Form
 {
-    #[Rule('required|string|email')]
+    #[Validate('required|string|email')]
     public string $email = '';
 
-    #[Rule('required|string')]
+    #[Validate('required|string')]
     public string $password = '';
 
-    #[Rule('boolean')]
+    #[Validate('boolean')]
     public bool $remember = false;
 
     /**


### PR DESCRIPTION
Since Livewire version 3.2.0, Livewire introduce the new Validate Attribute. The functionality is 100% the same as Rule Attribute and it will replace the Rule Attribute sometime in the newer version. Caleb Porzio make this change because of naming conflicts with Laravel rule objects.

Because the functionality is 100% the same, I don't think we need a new test.