### PR TITLE
asserting responses are ok before asserting presence of components

### DIFF
--- a/stubs/livewire-common/pest-tests/Feature/Auth/AuthenticationTest.php
+++ b/stubs/livewire-common/pest-tests/Feature/Auth/AuthenticationTest.php
@@ -8,8 +8,8 @@ test('login screen can be rendered', function () {
     $response = $this->get('/login');
 
     $response
-        ->assertSeeVolt('pages.auth.login')
-        ->assertOk();
+        ->assertOk()
+        ->assertSeeVolt('pages.auth.login');
 });
 
 test('users can authenticate using the login screen', function () {
@@ -52,8 +52,8 @@ test('navigation menu can be rendered', function () {
     $response = $this->get('/dashboard');
 
     $response
-        ->assertSeeVolt('layout.navigation')
-        ->assertOk();
+        ->assertOk()
+        ->assertSeeVolt('layout.navigation');
 });
 
 test('users can logout', function () {

--- a/stubs/livewire-common/pest-tests/Feature/Auth/RegistrationTest.php
+++ b/stubs/livewire-common/pest-tests/Feature/Auth/RegistrationTest.php
@@ -9,8 +9,8 @@ test('registration screen can be rendered', function () {
     $response = $this->get('/register');
 
     $response
-        ->assertSeeVolt('pages.auth.register')
-        ->assertOk();
+        ->assertOk()
+        ->assertSeeVolt('pages.auth.register');
 });
 
 test('new users can register', function () {

--- a/stubs/livewire-common/pest-tests/Feature/ProfileTest.php
+++ b/stubs/livewire-common/pest-tests/Feature/ProfileTest.php
@@ -11,10 +11,11 @@ test('profile page is displayed', function () {
     $response = $this->get('/profile');
 
     $response
+        ->assertOk()
         ->assertSeeVolt('profile.update-profile-information-form')
         ->assertSeeVolt('profile.update-password-form')
-        ->assertSeeVolt('profile.delete-user-form')
-        ->assertOk();
+        ->assertSeeVolt('profile.delete-user-form');
+
 });
 
 test('profile information can be updated', function () {

--- a/stubs/livewire-common/pest-tests/Feature/ProfileTest.php
+++ b/stubs/livewire-common/pest-tests/Feature/ProfileTest.php
@@ -15,7 +15,6 @@ test('profile page is displayed', function () {
         ->assertSeeVolt('profile.update-profile-information-form')
         ->assertSeeVolt('profile.update-password-form')
         ->assertSeeVolt('profile.delete-user-form');
-
 });
 
 test('profile information can be updated', function () {

--- a/stubs/livewire-common/tests/Feature/Auth/AuthenticationTest.php
+++ b/stubs/livewire-common/tests/Feature/Auth/AuthenticationTest.php
@@ -17,8 +17,8 @@ class AuthenticationTest extends TestCase
         $response = $this->get('/login');
 
         $response
-            ->assertSeeVolt('pages.auth.login')
-            ->assertOk();
+            ->assertOk()
+            ->assertSeeVolt('pages.auth.login');
     }
 
     public function test_users_can_authenticate_using_the_login_screen(): void
@@ -64,8 +64,8 @@ class AuthenticationTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response
-            ->assertSeeVolt('layout.navigation')
-            ->assertOk();
+            ->assertOk()
+            ->assertSeeVolt('layout.navigation');
     }
 
     public function test_users_can_logout(): void

--- a/stubs/livewire-common/tests/Feature/Auth/RegistrationTest.php
+++ b/stubs/livewire-common/tests/Feature/Auth/RegistrationTest.php
@@ -16,8 +16,8 @@ class RegistrationTest extends TestCase
         $response = $this->get('/register');
 
         $response
-            ->assertSeeVolt('pages.auth.register')
-            ->assertOk();
+            ->assertOk()
+            ->assertSeeVolt('pages.auth.register');
     }
 
     public function test_new_users_can_register(): void

--- a/stubs/livewire-common/tests/Feature/ProfileTest.php
+++ b/stubs/livewire-common/tests/Feature/ProfileTest.php
@@ -18,10 +18,10 @@ class ProfileTest extends TestCase
         $response = $this->actingAs($user)->get('/profile');
 
         $response
+            ->assertOk()
             ->assertSeeVolt('profile.update-profile-information-form')
             ->assertSeeVolt('profile.update-password-form')
-            ->assertSeeVolt('profile.delete-user-form')
-            ->assertOk();
+            ->assertSeeVolt('profile.delete-user-form');
     }
 
     public function test_profile_information_can_be_updated(): void


### PR DESCRIPTION
`assertOK()` should be made before `assertSeeVolt()` and other assertions. If response is not ok and `assertOK` is not first, it can be difficult to debug (this has bitten me before). 
