### PR TITLE
Added a x-on:close-modal.window directive so we can close modal from a livewire function

### DIFF
--- a/stubs/default/resources/views/components/modal.blade.php
+++ b/stubs/default/resources/views/components/modal.blade.php
@@ -40,6 +40,7 @@ $maxWidth = [
         }
     })"
     x-on:open-modal.window="$event.detail == '{{ $name }}' ? show = true : null"
+    x-on:close-modal.window="$event.detail == '{{ $name }}' ? show = false : null"
     x-on:close.stop="show = false"
     x-on:keydown.escape.window="show = false"
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"


### PR DESCRIPTION
Stumbled upon this issue in my project. Having this directive helped a ton. We could dispatch an event from the Livewire function (`$this->dispatch('close-modal', 'modal-name');`) so the modal can be closed after form submission. Hopefully, this helps others too.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
