### PR TITLE
Enable client site hydration in React stubs

### DIFF
--- a/stubs/inertia-react-ts/resources/js/app.tsx
+++ b/stubs/inertia-react-ts/resources/js/app.tsx
@@ -1,7 +1,7 @@
 import './bootstrap';
 import '../css/app.css';
 
-import { createRoot } from 'react-dom/client';
+import { hydrateRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 
@@ -11,9 +11,7 @@ createInertiaApp({
     title: (title) => `${title} - ${appName}`,
     resolve: (name) => resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx')),
     setup({ el, App, props }) {
-        const root = createRoot(el);
-
-        root.render(<App {...props} />);
+        hydrateRoot(el, <App {...props} />);
     },
     progress: {
         color: '#4B5563',

--- a/stubs/inertia-react/resources/js/app.jsx
+++ b/stubs/inertia-react/resources/js/app.jsx
@@ -1,7 +1,7 @@
 import './bootstrap';
 import '../css/app.css';
 
-import { createRoot } from 'react-dom/client';
+import { hydrateRoot } from 'react-dom/client';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 
@@ -11,9 +11,7 @@ createInertiaApp({
     title: (title) => `${title} - ${appName}`,
     resolve: (name) => resolvePageComponent(`./Pages/${name}.jsx`, import.meta.glob('./Pages/**/*.jsx')),
     setup({ el, App, props }) {
-        const root = createRoot(el);
-
-        root.render(<App {...props} />);
+        hydrateRoot(el, <App {...props} />);
     },
     progress: {
         color: '#4B5563',


### PR DESCRIPTION
The "Client side hydration" section in the SSR documentation of Inertia (https://inertiajs.com/server-side-rendering#client-side-hydration) mentions the following for React:

<img width="697" alt="grafik" src="https://github.com/laravel/breeze/assets/11889938/c2727829-9c37-46ab-b80c-853500ad2d1c">

This is currently not reflected in the React stubs for Breeze, they ship with `createRoot` by default.

This PR changes the calls in the JS and TS stubs.
