### PR TITLE
Add default value for useRef calls in .tsx files

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
@@ -9,7 +9,7 @@ import { useForm } from '@inertiajs/react';
 
 export default function DeleteUserForm({ className = '' }: { className?: string }) {
     const [confirmingUserDeletion, setConfirmingUserDeletion] = useState(false);
-    const passwordInput = useRef<HTMLInputElement>();
+    const passwordInput = useRef<HTMLInputElement>(null);
 
     const {
         data,

--- a/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/UpdatePasswordForm.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/UpdatePasswordForm.tsx
@@ -7,8 +7,8 @@ import { useForm } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
 
 export default function UpdatePasswordForm({ className = '' }: { className?: string }) {
-    const passwordInput = useRef<HTMLInputElement>();
-    const currentPasswordInput = useRef<HTMLInputElement>();
+    const passwordInput = useRef<HTMLInputElement>(null);
+    const currentPasswordInput = useRef<HTMLInputElement>(null);
 
     const { data, setData, errors, put, reset, processing, recentlySuccessful } = useForm({
         current_password: '',


### PR DESCRIPTION
This fixes missing default values for `useRef` calls that use generics, in this case `HTMLInputElement`.

Currently the returned value is inferred as `HTMLInputElement | null | undefined`. Adding null as a default value is better, since the returned value is inferred as `HTMLInputElement | null` due to the signature `function useRef<T>(initialValue: T | null): RefObject<T>;`.

I ran into this issue because I swapped the `<TextInput />` in the `<UpdatePasswordForm />` component with a different input component (https://ui.shadcn.com/docs/components/input), which caused an error when passing the `ref` down to the new component. Adding null as the default value fixed that issue.