### PR TITLE
[1.x] Use Livewire's `redirectIntended` function

### DIFF
--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -26,7 +26,7 @@ trait InstallsLivewireStack
         });
 
         // Install Livewire...
-        if (! $this->requireComposerPackages(['livewire/livewire:^3.0', 'livewire/volt:^1.0'])) {
+        if (! $this->requireComposerPackages(['livewire/livewire:^3.4', 'livewire/volt:^1.0'])) {
             return 1;
         }
 

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/confirm-password.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/confirm-password.blade.php
@@ -28,10 +28,7 @@ $confirmPassword = function () {
 
     session(['auth.password_confirmed_at' => time()]);
 
-    $this->redirect(
-        session('url.intended', RouteServiceProvider::HOME),
-        navigate: true
-    );
+    $this->redirectIntended(default: RouteServiceProvider::HOME, navigate: true);
 };
 
 ?>

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/login.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/login.blade.php
@@ -18,10 +18,7 @@ $login = function () {
 
     Session::regenerate();
 
-    $this->redirect(
-        session('url.intended', RouteServiceProvider::HOME),
-        navigate: true
-    );
+    $this->redirectIntended(default: RouteServiceProvider::HOME, navigate: true);
 };
 
 ?>

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/verify-email.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/verify-email.blade.php
@@ -11,10 +11,7 @@ layout('layouts.guest');
 
 $sendVerification = function () {
     if (Auth::user()->hasVerifiedEmail()) {
-        $this->redirect(
-            session('url.intended', RouteServiceProvider::HOME),
-            navigate: true
-        );
+        $this->redirectIntended(default: RouteServiceProvider::HOME, navigate: true);
 
         return;
     }

--- a/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -37,9 +37,7 @@ $sendVerification = function () {
     $user = Auth::user();
 
     if ($user->hasVerifiedEmail()) {
-        $path = session('url.intended', RouteServiceProvider::HOME);
-
-        $this->redirect($path);
+        $this->redirectIntended(default: RouteServiceProvider::HOME);
 
         return;
     }

--- a/stubs/livewire/resources/views/livewire/pages/auth/confirm-password.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/confirm-password.blade.php
@@ -30,10 +30,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         session(['auth.password_confirmed_at' => time()]);
 
-        $this->redirect(
-            session('url.intended', RouteServiceProvider::HOME),
-            navigate: true
-        );
+        $this->redirectIntended(default: RouteServiceProvider::HOME, navigate: true);
     }
 }; ?>
 

--- a/stubs/livewire/resources/views/livewire/pages/auth/login.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/login.blade.php
@@ -21,10 +21,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         Session::regenerate();
 
-        $this->redirect(
-            session('url.intended', RouteServiceProvider::HOME),
-            navigate: true
-        );
+        $this->redirectIntended(default: RouteServiceProvider::HOME, navigate: true);
     }
 }; ?>
 

--- a/stubs/livewire/resources/views/livewire/pages/auth/verify-email.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/verify-email.blade.php
@@ -15,10 +15,7 @@ new #[Layout('layouts.guest')] class extends Component
     public function sendVerification(): void
     {
         if (Auth::user()->hasVerifiedEmail()) {
-            $this->redirect(
-                session('url.intended', RouteServiceProvider::HOME),
-                navigate: true
-            );
+            $this->redirectIntended(default: RouteServiceProvider::HOME, navigate: true);
 
             return;
         }

--- a/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -52,9 +52,7 @@ new class extends Component
         $user = Auth::user();
 
         if ($user->hasVerifiedEmail()) {
-            $path = session('url.intended', RouteServiceProvider::HOME);
-
-            $this->redirect($path);
+            $this->redirectIntended(default: RouteServiceProvider::HOME);
 
             return;
         }


### PR DESCRIPTION
Since [Livewire 3.4](https://github.com/livewire/livewire/releases/tag/v3.4.0), the `redirectIntended` [function](https://livewire.laravel.com/docs/redirecting#redirect-to-intended) is available. This PR migrates the traditional redirects to this new function.