### PR TITLE
[2.x] Removes usages of abstract controller

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/api/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
-class AuthenticatedSessionController extends Controller
+class AuthenticatedSessionController
 {
     /**
      * Handle an incoming authentication request.

--- a/stubs/api/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/api/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
-class EmailVerificationNotificationController extends Controller
+class EmailVerificationNotificationController
 {
     /**
      * Send a new email verification notification.

--- a/stubs/api/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/api/app/Http/Controllers/Auth/NewPasswordController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -12,7 +11,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 
-class NewPasswordController extends Controller
+class NewPasswordController
 {
     /**
      * Handle an incoming new password request.

--- a/stubs/api/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/api/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 
-class PasswordResetLinkController extends Controller
+class PasswordResetLinkController
 {
     /**
      * Handle an incoming password reset link request.

--- a/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/api/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
@@ -11,7 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 
-class RegisteredUserController extends Controller
+class RegisteredUserController
 {
     /**
      * Handle an incoming registration request.

--- a/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 
-class VerifyEmailController extends Controller
+class VerifyEmailController
 {
     /**
      * Mark the authenticated user's email address as verified.

--- a/stubs/api/routes/auth.php
+++ b/stubs/api/routes/auth.php
@@ -9,29 +9,29 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/register', [RegisteredUserController::class, 'store'])
-                ->middleware('guest')
-                ->name('register');
+    ->middleware('guest')
+    ->name('register');
 
 Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-                ->middleware('guest')
-                ->name('login');
+    ->middleware('guest')
+    ->name('login');
 
 Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.email');
+    ->middleware('guest')
+    ->name('password.email');
 
 Route::post('/reset-password', [NewPasswordController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.store');
+    ->middleware('guest')
+    ->name('password.store');
 
 Route::get('/verify-email/{id}/{hash}', VerifyEmailController::class)
-                ->middleware(['auth', 'signed', 'throttle:6,1'])
-                ->name('verification.verify');
+    ->middleware(['auth', 'signed', 'throttle:6,1'])
+    ->name('verification.verify');
 
 Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware(['auth', 'throttle:6,1'])
-                ->name('verification.send');
+    ->middleware(['auth', 'throttle:6,1'])
+    ->name('verification.send');
 
 Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->middleware('auth')
-                ->name('logout');
+    ->middleware('auth')
+    ->name('logout');

--- a/stubs/default/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/default/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
-class AuthenticatedSessionController extends Controller
+class AuthenticatedSessionController
 {
     /**
      * Display the login view.

--- a/stubs/default/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
-class ConfirmablePasswordController extends Controller
+class ConfirmablePasswordController
 {
     /**
      * Show the confirm password view.

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
-class EmailVerificationNotificationController extends Controller
+class EmailVerificationNotificationController
 {
     /**
      * Send a new email verification notification.

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
-class EmailVerificationPromptController extends Controller
+class EmailVerificationPromptController
 {
     /**
      * Display the email verification prompt.

--- a/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -12,7 +11,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Illuminate\View\View;
 
-class NewPasswordController extends Controller
+class NewPasswordController
 {
     /**
      * Display the password reset view.

--- a/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/NewPasswordController.php
@@ -55,6 +55,6 @@ class NewPasswordController
         return $status == Password::PASSWORD_RESET
                     ? redirect()->route('login')->with('status', __($status))
                     : back()->withInput($request->only('email'))
-                            ->withErrors(['email' => __($status)]);
+                        ->withErrors(['email' => __($status)]);
     }
 }

--- a/stubs/default/app/Http/Controllers/Auth/PasswordController.php
+++ b/stubs/default/app/Http/Controllers/Auth/PasswordController.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 
-class PasswordController extends Controller
+class PasswordController
 {
     /**
      * Update the user's password.

--- a/stubs/default/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/default/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 use Illuminate\View\View;
 
-class PasswordResetLinkController extends Controller
+class PasswordResetLinkController
 {
     /**
      * Display the password reset link request view.

--- a/stubs/default/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/default/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -38,6 +38,6 @@ class PasswordResetLinkController
         return $status == Password::RESET_LINK_SENT
                     ? back()->with('status', __($status))
                     : back()->withInput($request->only('email'))
-                            ->withErrors(['email' => __($status)]);
+                        ->withErrors(['email' => __($status)]);
     }
 }

--- a/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/default/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
@@ -12,7 +11,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Illuminate\View\View;
 
-class RegisteredUserController extends Controller
+class RegisteredUserController
 {
     /**
      * Display the registration view.

--- a/stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 
-class VerifyEmailController extends Controller
+class VerifyEmailController
 {
     /**
      * Mark the authenticated user's email address as verified.

--- a/stubs/default/app/Http/Controllers/ProfileController.php
+++ b/stubs/default/app/Http/Controllers/ProfileController.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 
-class ProfileController extends Controller
+class ProfileController
 {
     /**
      * Display the user's profile form.

--- a/stubs/default/routes/auth.php
+++ b/stubs/default/routes/auth.php
@@ -13,47 +13,47 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+        ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
+        ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
+        ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
+        ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
+        ->name('password.reset');
 
     Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.store');
+        ->name('password.store');
 });
 
 Route::middleware('auth')->group(function () {
     Route::get('verify-email', EmailVerificationPromptController::class)
-                ->name('verification.notice');
+        ->name('verification.notice');
 
     Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
+        ->middleware(['signed', 'throttle:6,1'])
+        ->name('verification.verify');
 
     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
+        ->middleware('throttle:6,1')
+        ->name('verification.send');
 
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
+        ->name('password.confirm');
 
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+        ->name('logout');
 });

--- a/stubs/inertia-common/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -11,7 +10,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class AuthenticatedSessionController extends Controller
+class AuthenticatedSessionController
 {
     /**
      * Display the login view.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -10,7 +9,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class ConfirmablePasswordController extends Controller
+class ConfirmablePasswordController
 {
     /**
      * Show the confirm password view.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
-class EmailVerificationNotificationController extends Controller
+class EmailVerificationNotificationController
 {
     /**
      * Send a new email verification notification.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class EmailVerificationPromptController extends Controller
+class EmailVerificationPromptController
 {
     /**
      * Display the email verification prompt.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/NewPasswordController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -14,7 +13,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class NewPasswordController extends Controller
+class NewPasswordController
 {
     /**
      * Display the password reset view.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/PasswordController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/PasswordController.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 
-class PasswordController extends Controller
+class PasswordController
 {
     /**
      * Update the user's password.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
@@ -10,7 +9,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class PasswordResetLinkController extends Controller
+class PasswordResetLinkController
 {
     /**
      * Display the password reset link request view.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
@@ -13,7 +12,7 @@ use Illuminate\Validation\Rules;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class RegisteredUserController extends Controller
+class RegisteredUserController
 {
     /**
      * Display the registration view.

--- a/stubs/inertia-common/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/stubs/inertia-common/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -2,12 +2,11 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 
-class VerifyEmailController extends Controller
+class VerifyEmailController
 {
     /**
      * Mark the authenticated user's email address as verified.

--- a/stubs/inertia-common/app/Http/Controllers/ProfileController.php
+++ b/stubs/inertia-common/app/Http/Controllers/ProfileController.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class ProfileController extends Controller
+class ProfileController
 {
     /**
      * Display the user's profile form.

--- a/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia-common/app/Http/Middleware/HandleInertiaRequests.php
@@ -17,7 +17,7 @@ class HandleInertiaRequests extends Middleware
     /**
      * Determine the current asset version.
      */
-    public function version(Request $request): string|null
+    public function version(Request $request): ?string
     {
         return parent::version($request);
     }

--- a/stubs/inertia-common/routes/auth.php
+++ b/stubs/inertia-common/routes/auth.php
@@ -13,47 +13,47 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+        ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
+        ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
+        ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
+        ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
+        ->name('password.reset');
 
     Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.store');
+        ->name('password.store');
 });
 
 Route::middleware('auth')->group(function () {
     Route::get('verify-email', EmailVerificationPromptController::class)
-                ->name('verification.notice');
+        ->name('verification.notice');
 
     Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
+        ->middleware(['signed', 'throttle:6,1'])
+        ->name('verification.verify');
 
     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
+        ->middleware('throttle:6,1')
+        ->name('verification.send');
 
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
+        ->name('password.confirm');
 
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+        ->name('logout');
 });


### PR DESCRIPTION
This pull request removes usages of abstract controller, only for Laravel 11, aligned with https://github.com/laravel/laravel/pull/6331.

It also applies some Pint fixes to the current stubs.