### PR TITLE
Support distinct PK for `User` model

### DIFF
--- a/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
+++ b/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
@@ -15,9 +15,11 @@ class ProfileUpdateRequest extends FormRequest
      */
     public function rules(): array
     {
+        $user = $this->user();
+
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->getKey(), $user->getKeyName())],
         ];
     }
 }

--- a/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -19,7 +19,7 @@ $updateProfileInformation = function () {
 
     $validated = $this->validate([
         'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
+        'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->getKey(), $user->getKeyName())],
     ]);
 
     $user->fill($validated);

--- a/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -30,7 +30,7 @@ new class extends Component
 
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->getKey(), $user->getKeyName())],
         ]);
 
         $user->fill($validated);


### PR DESCRIPTION
Some projects use a distinct primary key for the `User` model. This change makes sure the validation constraint is checking the correct field with the correct value defined by the model class.
This affect the "Profile Information" form with the email field.