### PR TITLE
Improve default auth tests inside the stubs

### DIFF
--- a/stubs/api/pest-tests/Feature/Auth/PasswordResetTest.php
+++ b/stubs/api/pest-tests/Feature/Auth/PasswordResetTest.php
@@ -29,7 +29,9 @@ test('password can be reset with valid token', function () {
             'password_confirmation' => 'password',
         ]);
 
-        $response->assertSessionHasNoErrors();
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('login'));
 
         return true;
     });

--- a/stubs/api/pest-tests/Feature/Auth/PasswordResetTest.php
+++ b/stubs/api/pest-tests/Feature/Auth/PasswordResetTest.php
@@ -31,7 +31,7 @@ test('password can be reset with valid token', function () {
 
         $response
             ->assertSessionHasNoErrors()
-            ->assertRedirect(route('login'));
+            ->assertStatus(200);
 
         return true;
     });

--- a/stubs/api/tests/Feature/Auth/PasswordResetTest.php
+++ b/stubs/api/tests/Feature/Auth/PasswordResetTest.php
@@ -41,7 +41,7 @@ class PasswordResetTest extends TestCase
 
             $response
                 ->assertSessionHasNoErrors()
-                ->assertRedirect(route('login'));
+                ->assertStatus(200);
 
             return true;
         });

--- a/stubs/api/tests/Feature/Auth/PasswordResetTest.php
+++ b/stubs/api/tests/Feature/Auth/PasswordResetTest.php
@@ -39,7 +39,9 @@ class PasswordResetTest extends TestCase
                 'password_confirmation' => 'password',
             ]);
 
-            $response->assertSessionHasNoErrors();
+            $response
+                ->assertSessionHasNoErrors()
+                ->assertRedirect(route('login'));
 
             return true;
         });

--- a/stubs/default/pest-tests/Feature/Auth/PasswordResetTest.php
+++ b/stubs/default/pest-tests/Feature/Auth/PasswordResetTest.php
@@ -51,7 +51,9 @@ test('password can be reset with valid token', function () {
             'password_confirmation' => 'password',
         ]);
 
-        $response->assertSessionHasNoErrors();
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('login'));
 
         return true;
     });

--- a/stubs/default/tests/Feature/Auth/PasswordResetTest.php
+++ b/stubs/default/tests/Feature/Auth/PasswordResetTest.php
@@ -63,7 +63,9 @@ class PasswordResetTest extends TestCase
                 'password_confirmation' => 'password',
             ]);
 
-            $response->assertSessionHasNoErrors();
+            $response
+                ->assertSessionHasNoErrors()
+                ->assertRedirect(route('login'));
 
             return true;
         });


### PR DESCRIPTION
This PR improves tests that are delivered through fresh Breeze install.

Currently, a flaw is within `PasswordResetTest` -> `password can be reset with valid token` - it only checks for session error messages, while the `NewPasswordController` method `store` could be returning an internal error (HTTP code 500). 

Submitted changes adds a check for a successful return code which gives two things - there was no error in the controller logic and the resulting behaviour is in line with what is expected to happen. 