### PR TITLE
Update to Ziggy v2

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -15,7 +15,7 @@ trait InstallsInertiaStacks
     protected function installInertiaVueStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^0.6.8', 'laravel/sanctum:^3.2', 'tightenco/ziggy:^1.0'])) {
+        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^0.6.8', 'laravel/sanctum:^3.2', 'tightenco/ziggy:^2.0'])) {
             return 1;
         }
 
@@ -179,7 +179,7 @@ trait InstallsInertiaStacks
     protected function installInertiaReactStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^3.2', 'tightenco/ziggy:^1.0'])) {
+        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^0.6.3', 'laravel/sanctum:^3.2', 'tightenco/ziggy:^2.0'])) {
             return 1;
         }
 
@@ -349,7 +349,7 @@ trait InstallsInertiaStacks
             EOT,
             <<<'EOT'
             use Inertia\Middleware;
-            use Tightenco\Ziggy\Ziggy;
+            use Tighten\Ziggy\Ziggy;
             EOT,
             app_path('Http/Middleware/HandleInertiaRequests.php')
         );

--- a/stubs/inertia-react-ts/resources/js/ssr.tsx
+++ b/stubs/inertia-react-ts/resources/js/ssr.tsx
@@ -2,7 +2,7 @@ import ReactDOMServer from 'react-dom/server';
 import { createInertiaApp } from '@inertiajs/react';
 import createServer from '@inertiajs/react/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { route } from '../../vendor/tightenco/ziggy/dist';
+import { route } from '../../vendor/tightenco/ziggy';
 import { RouteName } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';

--- a/stubs/inertia-react-ts/resources/js/ssr.tsx
+++ b/stubs/inertia-react-ts/resources/js/ssr.tsx
@@ -2,7 +2,7 @@ import ReactDOMServer from 'react-dom/server';
 import { createInertiaApp } from '@inertiajs/react';
 import createServer from '@inertiajs/react/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import route from '../../vendor/tightenco/ziggy/dist/index.m';
+import { route } from '../../vendor/tightenco/ziggy/dist';
 import { RouteName } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';

--- a/stubs/inertia-react-ts/resources/js/types/global.d.ts
+++ b/stubs/inertia-react-ts/resources/js/types/global.d.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios';
-import ziggyRoute from 'ziggy-js';
+import { route as ziggyRoute } from 'ziggy-js';
 
 declare global {
     interface Window {

--- a/stubs/inertia-react/resources/js/ssr.jsx
+++ b/stubs/inertia-react/resources/js/ssr.jsx
@@ -2,7 +2,7 @@ import ReactDOMServer from 'react-dom/server';
 import { createInertiaApp } from '@inertiajs/react';
 import createServer from '@inertiajs/react/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { route } from '../../vendor/tightenco/ziggy/dist';
+import { route } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-react/resources/js/ssr.jsx
+++ b/stubs/inertia-react/resources/js/ssr.jsx
@@ -2,7 +2,7 @@ import ReactDOMServer from 'react-dom/server';
 import { createInertiaApp } from '@inertiajs/react';
 import createServer from '@inertiajs/react/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import route from '../../vendor/tightenco/ziggy/dist/index.m';
+import { route } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue-ts/resources/js/app.ts
+++ b/stubs/inertia-vue-ts/resources/js/app.ts
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createApp, h, DefineComponent } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue-ts/resources/js/app.ts
+++ b/stubs/inertia-vue-ts/resources/js/app.ts
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createApp, h, DefineComponent } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue-ts/resources/js/ssr.ts
+++ b/stubs/inertia-vue-ts/resources/js/ssr.ts
@@ -3,7 +3,7 @@ import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue-ts/resources/js/ssr.ts
+++ b/stubs/inertia-vue-ts/resources/js/ssr.ts
@@ -3,7 +3,7 @@ import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue-ts/resources/js/types/global.d.ts
+++ b/stubs/inertia-vue-ts/resources/js/types/global.d.ts
@@ -1,6 +1,6 @@
 import { PageProps as InertiaPageProps } from '@inertiajs/core';
 import { AxiosInstance } from 'axios';
-import ziggyRoute from 'ziggy-js';
+import { route as ziggyRoute } from 'ziggy-js';
 import { PageProps as AppPageProps } from './';
 
 declare global {

--- a/stubs/inertia-vue/resources/js/app.js
+++ b/stubs/inertia-vue/resources/js/app.js
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue/resources/js/app.js
+++ b/stubs/inertia-vue/resources/js/app.js
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue/resources/js/ssr.js
+++ b/stubs/inertia-vue/resources/js/ssr.js
@@ -3,7 +3,7 @@ import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia-vue/resources/js/ssr.js
+++ b/stubs/inertia-vue/resources/js/ssr.js
@@ -3,7 +3,7 @@ import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 


### PR DESCRIPTION
[Ziggy v2 was just released](https://github.com/tighten/ziggy/releases/tag/v2.0.0), this PR updates Breeze accordingly. Corresponding Jetstream PR: https://github.com/laravel/jetstream/pull/1442.

These changes only affect Breeze's install command and stubs, so they shouldn't have any impact on existing apps scaffolded with Breeze.