### PR TITLE
Controllers were not being copied when using livewire as setup guide.

### DIFF
--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -36,7 +36,7 @@ trait InstallsLivewireStack
             ->run();
 
         // Controllers
-        (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers/Auth'));
+        (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers'));
         (new Filesystem)->copy(
             __DIR__.'/../../stubs/default/app/Http/Controllers',
             app_path('Http/Controllers'),

--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -37,7 +37,7 @@ trait InstallsLivewireStack
 
         // Controllers
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers'));
-        (new Filesystem)->copy(
+        (new Filesystem)->copyDirectory(
             __DIR__.'/../../stubs/default/app/Http/Controllers',
             app_path('Http/Controllers'),
         );

--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -38,8 +38,8 @@ trait InstallsLivewireStack
         // Controllers
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers/Auth'));
         (new Filesystem)->copy(
-            __DIR__.'/../../stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php',
-            app_path('Http/Controllers/Auth/VerifyEmailController.php'),
+            __DIR__.'/../../stubs/default/app/Http/Controllers',
+            app_path('Http/Controllers'),
         );
 
         // Views...


### PR DESCRIPTION
When using breeze package with Livewire as a setup guide, the controllers were not being copied. 

Only the `stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php` to `Http/Controllers/Auth/VerifyEmailController.php`  but rest of the files in controller were being ignored resulting in breeze package not working as it should be. 