### PR TITLE
Add disabled styles for input field component

### DIFF
--- a/stubs/default/resources/views/components/text-input.blade.php
+++ b/stubs/default/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm']) !!}>
+<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm disabled:text-gray-500 disabled:dark:text-gray-500 disabled:border-gray-300 disabled:dark:border-gray-700 disabled:bg-gray-50 disabled:dark:bg-gray-900 disabled:cursor-not-allowed']) !!}>

--- a/stubs/inertia-react-ts/resources/js/Components/TextInput.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/TextInput.tsx
@@ -21,7 +21,7 @@ export default forwardRef(function TextInput(
             {...props}
             type={type}
             className={
-                'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm ' +
+                'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm disabled:text-gray-500 disabled:dark:text-gray-500 disabled:border-gray-300 disabled:dark:border-gray-700 disabled:bg-gray-50 disabled:dark:bg-gray-900 disabled:cursor-not-allowed ' +
                 className
             }
             ref={localRef}

--- a/stubs/inertia-react/resources/js/Components/TextInput.jsx
+++ b/stubs/inertia-react/resources/js/Components/TextInput.jsx
@@ -14,7 +14,7 @@ export default forwardRef(function TextInput({ type = 'text', className = '', is
             {...props}
             type={type}
             className={
-                'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm ' +
+                'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm disabled:text-gray-500 disabled:dark:text-gray-500 disabled:border-gray-300 disabled:dark:border-gray-700 disabled:bg-gray-50 disabled:dark:bg-gray-900 disabled:cursor-not-allowed ' +
                 className
             }
             ref={input}

--- a/stubs/inertia-vue-ts/resources/js/Components/TextInput.vue
+++ b/stubs/inertia-vue-ts/resources/js/Components/TextInput.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, ref } from 'vue';
 
 const model = defineModel<string>({ required: true });
 
 const input = ref<HTMLInputElement | null>(null);
 
 onMounted(() => {
-    if (input.value?.hasAttribute("autofocus")) {
+    if (input.value?.hasAttribute('autofocus')) {
         input.value?.focus();
     }
 });

--- a/stubs/inertia-vue-ts/resources/js/Components/TextInput.vue
+++ b/stubs/inertia-vue-ts/resources/js/Components/TextInput.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, ref } from "vue";
 
 const model = defineModel<string>({ required: true });
 
 const input = ref<HTMLInputElement | null>(null);
 
 onMounted(() => {
-    if (input.value?.hasAttribute('autofocus')) {
+    if (input.value?.hasAttribute("autofocus")) {
         input.value?.focus();
     }
 });
@@ -16,7 +16,7 @@ defineExpose({ focus: () => input.value?.focus() });
 
 <template>
     <input
-        class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm"
+        class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm disabled:text-gray-500 disabled:dark:text-gray-500 disabled:border-gray-300 disabled:dark:border-gray-700 disabled:bg-gray-50 disabled:dark:bg-gray-900 disabled:cursor-not-allowed"
         v-model="model"
         ref="input"
     />

--- a/stubs/inertia-vue/resources/js/Components/TextInput.vue
+++ b/stubs/inertia-vue/resources/js/Components/TextInput.vue
@@ -19,7 +19,7 @@ defineExpose({ focus: () => input.value.focus() });
 
 <template>
     <input
-        class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm"
+        class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm disabled:text-gray-500 disabled:dark:text-gray-500 disabled:border-gray-300 disabled:dark:border-gray-700 disabled:bg-gray-50 disabled:dark:bg-gray-900 disabled:cursor-not-allowed"
         v-model="model"
         ref="input"
     />


### PR DESCRIPTION
I've opened this pull request to make a small enhancement to Laravel Breeze by adding styles for disabled input fields. Although it's a minor change, I believe it's worth it to improve the clarity and cleanliness of the disabled state. Let me know if you want me to make any further changes. If you think it's unnecessary, that's fine, too.

Before:
![image](https://github.com/laravel/breeze/assets/134765302/0b6290a1-7aea-4ec6-8802-d83238568a35)

After:
![image](https://github.com/laravel/breeze/assets/134765302/af1b8234-b5c3-4a46-84c8-976fd1827172)
