### PR TITLE
Updated throttleKey method to meet Str::lower excepted value in LoginRequest stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
-.idea/

--- a/stubs/default/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/default/app/Http/Requests/Auth/LoginRequest.php
@@ -80,6 +80,6 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->input('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
     }
 }


### PR DESCRIPTION
This is a simple fix that allows PHPStan level 9 to pass validation on this request file.

`Str::lower` expects the value given to be a string, however, `$this->input('email')` returns mixed, causes PHPStan to fail at level 9.

We can not cast the value to a string as an error is thrown when trying to cast a mixed object.

```php
(string) $this->input('email') // Causes an error
```

This does not cause any breaking changes and leverages the "Illuminate\Http\Concerns\InteractsWithInput" class.

Edit: Fixed a typo.