### PR TITLE
Adds a check for the existence of the `resources/views` directory before adding `.gitkeep`

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -85,6 +85,9 @@ trait InstallsApiStack
 
         // Remove Laravel "welcome" view...
         $files->delete(resource_path('views/welcome.blade.php'));
+        if (! $files->isDirectory(resource_path('views'))) {
+            $files->makeDirectory(resource_path('views'), 0755, true);
+        }
         $files->put(resource_path('views/.gitkeep'), PHP_EOL);
 
         // Remove CSS and JavaScript directories...


### PR DESCRIPTION
When developing an api application, directories `resources/views` or even `resources` may be deleted before breeze installation. When installing breeze with the `api` option, copying stub files to such projects breaks down.

PR adds a simple check for the existence of such directories before creating the `resources/views/.gitkeep` file.

[Similar issue](https://github.com/laravel/framework/issues/50586)