### PR TITLE
[2.x] Prevents remove `dark` classes from `livewire/welcome/navigation.blade.php`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -78,6 +78,7 @@ trait InstallsLivewireStack
             $this->removeDarkClasses((new Finder)
                 ->in(resource_path('views'))
                 ->name('*.blade.php')
+                ->notPath('livewire/welcome/navigation.blade.php')
                 ->notName('welcome.blade.php')
             );
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request aims to add `notPath` to Finder to avoid removing `dark` classes from `resources/views/livewire/welcome/navigation.blade.php`. When `dark` is removed from this file the Login and Registration links become invisible:

![CleanShot 2024-03-21 at 14 01 04](https://github.com/laravel/breeze/assets/60591772/5b44abbe-0525-4817-8cfa-dfce2e169098)

![CleanShot 2024-03-21 at 14 01 50](https://github.com/laravel/breeze/assets/60591772/dfd1fd8a-e7cc-42b0-ab9e-2a82346f0646)
