### PR TITLE
[2.x] Fixes non dark mode on Livewire's `welcome/navigation.blade.php`

### DIFF
--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -41,6 +41,7 @@ trait InstallsBladeStack
             $this->removeDarkClasses((new Finder)
                 ->in(resource_path('views'))
                 ->name('*.blade.php')
+                ->notPath('livewire/welcome/navigation.blade.php')
                 ->notName('welcome.blade.php')
             );
         }

--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -78,6 +78,7 @@ trait InstallsLivewireStack
             $this->removeDarkClasses((new Finder)
                 ->in(resource_path('views'))
                 ->name('*.blade.php')
+                ->notPath('livewire/welcome/navigation.blade.php')
                 ->notName('welcome.blade.php')
             );
         }


### PR DESCRIPTION
This pull request complements https://github.com/laravel/breeze/pull/374, by fixing Livewire stacks on Breeze when non-dark mode is selected.