### PR TITLE
Passing hint in multiselect.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -379,7 +379,8 @@ class InstallCommand extends Command implements PromptsForMissingInput
                     'dark' => 'Dark mode',
                     'ssr' => 'Inertia SSR',
                     'typescript' => 'TypeScript (experimental)',
-                ]
+                ],
+                hint: 'Use the space bar to select options.',
             ))->each(fn ($option) => $input->setOption($option, true));
         } elseif (in_array($stack, ['blade', 'livewire', 'livewire-functional'])) {
             $input->setOption('dark', confirm(


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It is hard for a beginner or anyone without knowledge about console applications to find out how to select in multi-select. 
For example, he needs something from optional like dark more, ssr but doesn't know how to select that, press enter, and shows nothing is selected. So, for an easier way to install and better UX, there should be a hint, on how to select in multi-select.
No breaking change just passed a hint string which is also a default string in helper.
