### PR TITLE
Use post named routes inside of blade files

### DIFF
--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -2,7 +2,7 @@
     <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
 
-    <form method="POST" action="{{ route('login') }}">
+    <form method="POST" action="{{ route('login.store') }}">
         @csrf
 
         <!-- Email Address -->

--- a/stubs/default/resources/views/auth/register.blade.php
+++ b/stubs/default/resources/views/auth/register.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <form method="POST" action="{{ route('register') }}">
+    <form method="POST" action="{{ route('register.store') }}">
         @csrf
 
         <!-- Name -->

--- a/stubs/default/routes/auth.php
+++ b/stubs/default/routes/auth.php
@@ -15,12 +15,14 @@ Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
                 ->name('register');
 
-    Route::post('register', [RegisteredUserController::class, 'store']);
+    Route::post('register', [RegisteredUserController::class, 'store'])
+                ->name('register.store');
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
                 ->name('login');
 
-    Route::post('login', [AuthenticatedSessionController::class, 'store']);
+    Route::post('login', [AuthenticatedSessionController::class, 'store'])
+                ->name('login.store');
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
                 ->name('password.request');


### PR DESCRIPTION
Currently, we are using named routes for both register and login, but it is pointed to the get method.

But in case we want to make any changes to the route path for example as below we get a 405 method not allowed exception

```php
    Route::get('admin/login', [AuthenticatedSessionController::class, 'create'])
        ->name('login');
```

<img width="1438" alt="image" src="https://github.com/laravel/breeze/assets/48653948/d896dadd-d1e8-478a-96af-c0e93d9e1310">

I have instead provided a name to the post route and used them in the blade forms.