### PR TITLE
[2.x] Fix React TS errors

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Welcome.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Welcome.tsx
@@ -86,7 +86,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }: PageProps<
                                             </div>
                                         </div>
 
-                                        <svg className="size-6 shrink-0 stroke-[#FF2D20]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"/></svg>
+                                        <svg className="size-6 shrink-0 stroke-[#FF2D20]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5"><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"/></svg>
                                     </div>
                                 </a>
 
@@ -106,7 +106,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }: PageProps<
                                         </p>
                                     </div>
 
-                                    <svg className="size-6 shrink-0 self-center stroke-[#FF2D20]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"/></svg>
+                                    <svg className="size-6 shrink-0 self-center stroke-[#FF2D20]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5"><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"/></svg>
                                 </a>
 
                                 <a
@@ -125,7 +125,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }: PageProps<
                                         </p>
                                     </div>
 
-                                    <svg className="size-6 shrink-0 self-center stroke-[#FF2D20]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"/></svg>
+                                    <svg className="size-6 shrink-0 self-center stroke-[#FF2D20]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5"><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"/></svg>
                                 </a>
 
                                 <div className="flex items-start gap-4 rounded-lg bg-white p-6 shadow-[0px_14px_34px_0px_rgba(0,0,0,0.08)] ring-1 ring-white/[0.05] lg:pb-10 dark:bg-zinc-900 dark:ring-zinc-800">

--- a/stubs/inertia-react-ts/resources/js/ssr.tsx
+++ b/stubs/inertia-react-ts/resources/js/ssr.tsx
@@ -15,7 +15,7 @@ createServer((page) =>
         resolve: (name) => resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx')),
         setup: ({ App, props }) => {
             global.route<RouteName> = (name, params, absolute) =>
-                route(name, params, absolute, {
+                route(name, params as any, absolute, {
                     // @ts-expect-error
                     ...page.props.ziggy,
                     // @ts-expect-error

--- a/stubs/inertia-react/resources/js/Pages/Welcome.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Welcome.jsx
@@ -124,11 +124,11 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
                                             xmlns="http://www.w3.org/2000/svg"
                                             fill="none"
                                             viewBox="0 0 24 24"
-                                            stroke-width="1.5"
+                                            strokeWidth="1.5"
                                         >
                                             <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
                                                 d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"
                                             />
                                         </svg>
@@ -167,11 +167,11 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
                                         xmlns="http://www.w3.org/2000/svg"
                                         fill="none"
                                         viewBox="0 0 24 24"
-                                        stroke-width="1.5"
+                                        strokeWidth="1.5"
                                     >
                                         <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
                                             d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"
                                         />
                                     </svg>
@@ -213,11 +213,11 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
                                         xmlns="http://www.w3.org/2000/svg"
                                         fill="none"
                                         viewBox="0 0 24 24"
-                                        stroke-width="1.5"
+                                        strokeWidth="1.5"
                                     >
                                         <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
                                             d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"
                                         />
                                     </svg>


### PR DESCRIPTION
This PR fixes the following TypeScript error in the React SSR build:

```
 resources/js/ssr.tsx(18,17): error TS2769: No overload matches this call.
  Overload 1 of 4, '(name: string & {}, params?: RouteParams<string & {}> | undefined, absolute?: boolean | undefined, config?: Config | undefined): string', gave the following error.
    Argument of type 'ParameterValue | RouteParams<string & {}> | undefined' is not assignable to parameter of type 'RouteParams<string & {}> | undefined'.
      Type 'string' is not assignable to type 'RouteParams<string & {}> | undefined'.
  Overload 2 of 4, '(name: string & {}, params?: ParameterValue | undefined, absolute?: boolean | undefined, config?: Config | undefined): string', gave the following error.
    Argument of type 'ParameterValue | RouteParams<string & {}> | undefined' is not assignable to parameter of type 'ParameterValue | undefined'.
      Type 'GenericRouteParamsObject' is not assignable to type 'ParameterValue | undefined'.
        Type 'GenericRouteParamsObject' is not assignable to type 'DefaultRoutable'.
          Property 'id' is missing in type 'GenericRouteParamsObject' but required in type '{ id: RawParameterValue; }'.
  Overload 3 of 4, '(name: undefined, params: undefined, absolute?: boolean | undefined, config?: Config | undefined): Router', gave the following error.
    Argument of type 'string & {}' is not assignable to parameter of type 'undefined'.
```

It also fixes a JSX/TSX syntax issue in the default welcome page that caused errors when running the SSR server.