### PR TITLE
Introduce new Logic to support FRONTEND_URL with custom port

### DIFF
--- a/stubs/api/config/sanctum.php
+++ b/stubs/api/config/sanctum.php
@@ -19,7 +19,7 @@ return [
         '%s%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),
-        env('FRONTEND_URL') ? ','.parse_url(env('FRONTEND_URL'), PHP_URL_HOST) : ''
+        env('FRONTEND_URL') ? ',' . parse_url(env('FRONTEND_URL'), PHP_URL_HOST) . (parse_url(env('FRONTEND_URL'), PHP_URL_PORT) ? ':' . parse_url(env('FRONTEND_URL'), PHP_URL_PORT) : '') : ''
     ))),
 
     /*


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
ISSUE:
I was working on a different project, I'm using Laravel as my API and I have to use a different port for my front end (NextJS), I noticed that I'm having an error connecting the two.

CONCLUSION:
Only to find out, the custom port for `FRONTEND_URL` provided in `.env` is not included.
It only work if you have set the port to `3000` or `8000`

SOLUTION:
The work around for this is to add the `FRONTEND_URL` in your Laravel `.env`

```php
 SANCTUM_STATEFUL_DOMAINS={FRONTEND_URL} 
```

To solve this redundant declaration, it edited the `config/sanctum.php` file to return the `FRONTEND_URL` with the custom port if set, else just the host.