### PR TITLE
Update NewPasswordController.php

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/stubs/api/app/Http/Controllers/Auth/NewPasswordController.php
@@ -34,7 +34,7 @@ class NewPasswordController extends Controller
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function ($user) use ($request) {
                 $user->forceFill([
-                    'password' => Hash::make($request->password),
+                    'password' => Hash::make($request->string('password')),
                     'remember_token' => Str::random(60),
                 ])->save();
 


### PR DESCRIPTION
Use $request->string(password) to resolve this error on PHPStan level 9:

```
Parameter #1 $value of static method Illuminate\Support\Facades\Hash::make() expects string, mixed given.
         ✏️  app\Http\Controllers\Auth\NewPasswordController.php

```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
