### PR TITLE
fix: add `hydrateRoot` when react ssr enabled

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -369,7 +369,7 @@ trait InstallsInertiaStacks
                 <<<'EOT'
                 import { createRoot, hydrateRoot } from 'react-dom/client';
                 EOT,
-                resource_path('js/app.js')
+                resource_path('js/app.jsx')
             );
 
             $this->replaceInFile(
@@ -386,7 +386,7 @@ trait InstallsInertiaStacks
     
                         hydrateRoot(el, <App {...props} />);
                 EOT,
-                resource_path('js/app.js')
+                resource_path('js/app.jsx')
             );
         }
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -333,37 +333,64 @@ trait InstallsInertiaStacks
         if ($this->option('typescript')) {
             copy(__DIR__.'/../../stubs/inertia-react-ts/resources/js/ssr.tsx', resource_path('js/ssr.tsx'));
             $this->replaceInFile("input: 'resources/js/app.tsx',", "input: 'resources/js/app.tsx',".PHP_EOL."            ssr: 'resources/js/ssr.tsx',", base_path('vite.config.js'));
+            
+            $this->replaceInFile(
+                <<<'EOT'
+                import { createRoot } from 'react-dom/client';
+                EOT,
+                <<<'EOT'
+                import { createRoot, hydrateRoot } from 'react-dom/client';
+                EOT,
+                resource_path('js/app.tsx')
+            );
+    
+            $this->replaceInFile(
+                <<<'EOT'
+                        const root = createRoot(el);
+    
+                        root.render(<App {...props} />);
+                EOT,
+                <<<'EOT'
+                        if (import.meta.env.DEV) {
+                            createRoot(el).render(<App {...props} />);
+                            return
+                        }
+    
+                        hydrateRoot(el, <App {...props} />);
+                EOT,
+                resource_path('js/app.tsx')
+            );
         } else {
             copy(__DIR__.'/../../stubs/inertia-react/resources/js/ssr.jsx', resource_path('js/ssr.jsx'));
             $this->replaceInFile("input: 'resources/js/app.jsx',", "input: 'resources/js/app.jsx',".PHP_EOL."            ssr: 'resources/js/ssr.jsx',", base_path('vite.config.js'));
+            
+            $this->replaceInFile(
+                <<<'EOT'
+                import { createRoot } from 'react-dom/client';
+                EOT,
+                <<<'EOT'
+                import { createRoot, hydrateRoot } from 'react-dom/client';
+                EOT,
+                resource_path('js/app.js')
+            );
+    
+            $this->replaceInFile(
+                <<<'EOT'
+                        const root = createRoot(el);
+    
+                        root.render(<App {...props} />);
+                EOT,
+                <<<'EOT'
+                        if (import.meta.env.DEV) {
+                            createRoot(el).render(<App {...props} />);
+                            return
+                        }
+    
+                        hydrateRoot(el, <App {...props} />);
+                EOT,
+                resource_path('js/app.js')
+            );
         }
-
-        $this->replaceInFile(
-            <<<'EOT'
-            import { createRoot } from 'react-dom/client';
-            EOT,
-            <<<'EOT'
-            import { createRoot, hydrateRoot } from 'react-dom/client';
-            EOT,
-            resource_path('js/app.tsx')
-        );
-
-        $this->replaceInFile(
-            <<<'EOT'
-                    const root = createRoot(el);
-
-                    root.render(<App {...props} />);
-            EOT,
-            <<<'EOT'
-                    if (import.meta.env.DEV) {
-                        createRoot(el).render(<App {...props} />);
-                        return
-                    }
-
-                    hydrateRoot(el, <App {...props} />);
-            EOT,
-            resource_path('js/app.tsx')
-        );
 
         $this->configureZiggyForSsr();
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -333,7 +333,6 @@ trait InstallsInertiaStacks
         if ($this->option('typescript')) {
             copy(__DIR__.'/../../stubs/inertia-react-ts/resources/js/ssr.tsx', resource_path('js/ssr.tsx'));
             $this->replaceInFile("input: 'resources/js/app.tsx',", "input: 'resources/js/app.tsx',".PHP_EOL."            ssr: 'resources/js/ssr.tsx',", base_path('vite.config.js'));
-            
             $this->replaceInFile(
                 <<<'EOT'
                 import { createRoot } from 'react-dom/client';
@@ -343,7 +342,7 @@ trait InstallsInertiaStacks
                 EOT,
                 resource_path('js/app.tsx')
             );
-    
+
             $this->replaceInFile(
                 <<<'EOT'
                         const root = createRoot(el);
@@ -363,7 +362,6 @@ trait InstallsInertiaStacks
         } else {
             copy(__DIR__.'/../../stubs/inertia-react/resources/js/ssr.jsx', resource_path('js/ssr.jsx'));
             $this->replaceInFile("input: 'resources/js/app.jsx',", "input: 'resources/js/app.jsx',".PHP_EOL."            ssr: 'resources/js/ssr.jsx',", base_path('vite.config.js'));
-            
             $this->replaceInFile(
                 <<<'EOT'
                 import { createRoot } from 'react-dom/client';
@@ -373,7 +371,7 @@ trait InstallsInertiaStacks
                 EOT,
                 resource_path('js/app.js')
             );
-    
+
             $this->replaceInFile(
                 <<<'EOT'
                         const root = createRoot(el);

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -338,6 +338,33 @@ trait InstallsInertiaStacks
             $this->replaceInFile("input: 'resources/js/app.jsx',", "input: 'resources/js/app.jsx',".PHP_EOL."            ssr: 'resources/js/ssr.jsx',", base_path('vite.config.js'));
         }
 
+        $this->replaceInFile(
+            <<<'EOT'
+            import { createRoot } from 'react-dom/client';
+            EOT,
+            <<<'EOT'
+            import { createRoot, hydrateRoot } from 'react-dom/client';
+            EOT,
+            resource_path('js/app.tsx')
+        );
+
+        $this->replaceInFile(
+            <<<'EOT'
+                    const root = createRoot(el);
+
+                    root.render(<App {...props} />);
+            EOT,
+            <<<'EOT'
+                    if (import.meta.env.DEV) {
+                        createRoot(el).render(<App {...props} />);
+                        return
+                    }
+
+                    hydrateRoot(el, <App {...props} />);
+            EOT,
+            resource_path('js/app.tsx')
+        );
+
         $this->configureZiggyForSsr();
 
         $this->replaceInFile('vite build', 'vite build && vite build --ssr', base_path('package.json'));

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -333,67 +333,53 @@ trait InstallsInertiaStacks
         if ($this->option('typescript')) {
             copy(__DIR__.'/../../stubs/inertia-react-ts/resources/js/ssr.tsx', resource_path('js/ssr.tsx'));
             $this->replaceInFile("input: 'resources/js/app.tsx',", "input: 'resources/js/app.tsx',".PHP_EOL."            ssr: 'resources/js/ssr.tsx',", base_path('vite.config.js'));
-            $this->replaceInFile(
-                <<<'EOT'
-                import { createRoot } from 'react-dom/client';
-                EOT,
-                <<<'EOT'
-                import { createRoot, hydrateRoot } from 'react-dom/client';
-                EOT,
-                resource_path('js/app.tsx')
-            );
-
-            $this->replaceInFile(
-                <<<'EOT'
-                        const root = createRoot(el);
-    
-                        root.render(<App {...props} />);
-                EOT,
-                <<<'EOT'
-                        if (import.meta.env.DEV) {
-                            createRoot(el).render(<App {...props} />);
-                            return
-                        }
-    
-                        hydrateRoot(el, <App {...props} />);
-                EOT,
-                resource_path('js/app.tsx')
-            );
+            $this->configureReactHydrateRootForSsr(resource_path('js/app.tsx'));
         } else {
             copy(__DIR__.'/../../stubs/inertia-react/resources/js/ssr.jsx', resource_path('js/ssr.jsx'));
             $this->replaceInFile("input: 'resources/js/app.jsx',", "input: 'resources/js/app.jsx',".PHP_EOL."            ssr: 'resources/js/ssr.jsx',", base_path('vite.config.js'));
-            $this->replaceInFile(
-                <<<'EOT'
-                import { createRoot } from 'react-dom/client';
-                EOT,
-                <<<'EOT'
-                import { createRoot, hydrateRoot } from 'react-dom/client';
-                EOT,
-                resource_path('js/app.jsx')
-            );
-
-            $this->replaceInFile(
-                <<<'EOT'
-                        const root = createRoot(el);
-    
-                        root.render(<App {...props} />);
-                EOT,
-                <<<'EOT'
-                        if (import.meta.env.DEV) {
-                            createRoot(el).render(<App {...props} />);
-                            return
-                        }
-    
-                        hydrateRoot(el, <App {...props} />);
-                EOT,
-                resource_path('js/app.jsx')
-            );
+            $this->configureReactHydrateRootForSsr(resource_path('js/app.jsx'));
         }
 
         $this->configureZiggyForSsr();
 
         $this->replaceInFile('vite build', 'vite build && vite build --ssr', base_path('package.json'));
         $this->replaceInFile('/node_modules', '/bootstrap/ssr'.PHP_EOL.'/node_modules', base_path('.gitignore'));
+    }
+
+    /**
+     * Configure the application JavaScript file to utilize hydrateRoot for SSR.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function configureReactHydrateRootForSsr($path)
+    {
+        $this->replaceInFile(
+            <<<'EOT'
+            import { createRoot } from 'react-dom/client';
+            EOT,
+            <<<'EOT'
+            import { createRoot, hydrateRoot } from 'react-dom/client';
+            EOT,
+            $path
+        );
+
+        $this->replaceInFile(
+            <<<'EOT'
+                    const root = createRoot(el);
+
+                    root.render(<App {...props} />);
+            EOT,
+            <<<'EOT'
+                    if (import.meta.env.DEV) {
+                        createRoot(el).render(<App {...props} />);
+                        return
+                    }
+
+                    hydrateRoot(el, <App {...props} />);
+            EOT,
+            $path
+        );
     }
 
     /**


### PR DESCRIPTION
This PR adds [missing](https://react.dev/reference/react-dom/client/hydrateRoot) `hydrateRoot` to client entry, when React SSR is enabled.

In addition it keeps `createRoot` for development.

EDIT: I couln't get a condition inside `resource_path` for `$this->option('typescript')` working to reduce the code duplication.