### PR TITLE
Bump `@headlessui/react` to v2

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -190,7 +190,7 @@ trait InstallsInertiaStacks
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@headlessui/react' => '^1.4.2',
+                '@headlessui/react' => '^2.0.0',
                 '@inertiajs/react' => '^1.0.0',
                 '@tailwindcss/forms' => '^0.5.3',
                 '@vitejs/plugin-react' => '^4.2.0',

--- a/stubs/inertia-react-ts/resources/js/Components/Dropdown.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, createContext, useContext, Fragment, PropsWithChildren, Dispatch, SetStateAction } from 'react';
+import { useState, createContext, useContext, PropsWithChildren, Dispatch, SetStateAction } from 'react';
 import { Link, InertiaLinkProps } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
 
@@ -58,7 +58,6 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
     return (
         <>
             <Transition
-                as={Fragment}
                 show={open}
                 enter="transition ease-out duration-200"
                 enterFrom="opacity-0 scale-95"

--- a/stubs/inertia-react-ts/resources/js/Components/Modal.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Modal.tsx
@@ -1,5 +1,5 @@
-import { Fragment, PropsWithChildren } from 'react';
-import { Dialog, Transition } from '@headlessui/react';
+import { PropsWithChildren } from 'react';
+import { Dialog, DialogPanel, Transition, TransitionChild } from '@headlessui/react';
 
 export default function Modal({
     children,
@@ -35,7 +35,7 @@ export default function Modal({
                 className="fixed inset-0 flex overflow-y-auto px-4 py-6 sm:px-0 items-center z-50 transform transition-all"
                 onClose={close}
             >
-                <Transition.Child
+                <TransitionChild
                     enter="ease-out duration-300"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
@@ -44,9 +44,9 @@ export default function Modal({
                     leaveTo="opacity-0"
                 >
                     <div className="absolute inset-0 bg-gray-500/75 dark:bg-gray-900/75" />
-                </Transition.Child>
+                </TransitionChild>
 
-                <Transition.Child
+                <TransitionChild
                     enter="ease-out duration-300"
                     enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     enterTo="opacity-100 translate-y-0 sm:scale-100"
@@ -54,12 +54,12 @@ export default function Modal({
                     leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                     leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                 >
-                    <Dialog.Panel
+                    <DialogPanel
                         className={`mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto ${maxWidthClass}`}
                     >
                         {children}
-                    </Dialog.Panel>
-                </Transition.Child>
+                    </DialogPanel>
+                </TransitionChild>
             </Dialog>
         </Transition>
     );

--- a/stubs/inertia-react-ts/resources/js/Components/Modal.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Modal.tsx
@@ -28,7 +28,7 @@ export default function Modal({
     }[maxWidth];
 
     return (
-        <Transition show={show} as={Fragment} leave="duration-200">
+        <Transition show={show} leave="duration-200">
             <Dialog
                 as="div"
                 id="modal"
@@ -36,7 +36,6 @@ export default function Modal({
                 onClose={close}
             >
                 <Transition.Child
-                    as={Fragment}
                     enter="ease-out duration-300"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
@@ -48,7 +47,6 @@ export default function Modal({
                 </Transition.Child>
 
                 <Transition.Child
-                    as={Fragment}
                     enter="ease-out duration-300"
                     enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     enterTo="opacity-100 translate-y-0 sm:scale-100"

--- a/stubs/inertia-react/resources/js/Components/Dropdown.jsx
+++ b/stubs/inertia-react/resources/js/Components/Dropdown.jsx
@@ -1,4 +1,4 @@
-import { useState, createContext, useContext, Fragment } from 'react';
+import { useState, createContext, useContext } from 'react';
 import { Link } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
 
@@ -50,7 +50,6 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
     return (
         <>
             <Transition
-                as={Fragment}
                 show={open}
                 enter="transition ease-out duration-200"
                 enterFrom="opacity-0 scale-95"

--- a/stubs/inertia-react/resources/js/Components/Modal.jsx
+++ b/stubs/inertia-react/resources/js/Components/Modal.jsx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 
 export default function Modal({ children, show = false, maxWidth = '2xl', closeable = true, onClose = () => {} }) {
@@ -17,7 +16,7 @@ export default function Modal({ children, show = false, maxWidth = '2xl', closea
     }[maxWidth];
 
     return (
-        <Transition show={show} as={Fragment} leave="duration-200">
+        <Transition show={show} leave="duration-200">
             <Dialog
                 as="div"
                 id="modal"
@@ -25,7 +24,6 @@ export default function Modal({ children, show = false, maxWidth = '2xl', closea
                 onClose={close}
             >
                 <Transition.Child
-                    as={Fragment}
                     enter="ease-out duration-300"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
@@ -37,7 +35,6 @@ export default function Modal({ children, show = false, maxWidth = '2xl', closea
                 </Transition.Child>
 
                 <Transition.Child
-                    as={Fragment}
                     enter="ease-out duration-300"
                     enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     enterTo="opacity-100 translate-y-0 sm:scale-100"

--- a/stubs/inertia-react/resources/js/Components/Modal.jsx
+++ b/stubs/inertia-react/resources/js/Components/Modal.jsx
@@ -1,4 +1,4 @@
-import { Dialog, Transition } from '@headlessui/react';
+import { Dialog, DialogPanel, Transition, TransitionChild } from '@headlessui/react';
 
 export default function Modal({ children, show = false, maxWidth = '2xl', closeable = true, onClose = () => {} }) {
     const close = () => {
@@ -23,7 +23,7 @@ export default function Modal({ children, show = false, maxWidth = '2xl', closea
                 className="fixed inset-0 flex overflow-y-auto px-4 py-6 sm:px-0 items-center z-50 transform transition-all"
                 onClose={close}
             >
-                <Transition.Child
+                <TransitionChild
                     enter="ease-out duration-300"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
@@ -32,9 +32,9 @@ export default function Modal({ children, show = false, maxWidth = '2xl', closea
                     leaveTo="opacity-0"
                 >
                     <div className="absolute inset-0 bg-gray-500/75 dark:bg-gray-900/75" />
-                </Transition.Child>
+                </TransitionChild>
 
-                <Transition.Child
+                <TransitionChild
                     enter="ease-out duration-300"
                     enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     enterTo="opacity-100 translate-y-0 sm:scale-100"
@@ -42,12 +42,12 @@ export default function Modal({ children, show = false, maxWidth = '2xl', closea
                     leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                     leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                 >
-                    <Dialog.Panel
+                    <DialogPanel
                         className={`mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto ${maxWidthClass}`}
                     >
                         {children}
-                    </Dialog.Panel>
-                </Transition.Child>
+                    </DialogPanel>
+                </TransitionChild>
             </Dialog>
         </Transition>
     );


### PR DESCRIPTION
This PR bumps `@headlessui/react` to the latest v2 version.

There are 3 relevant changes at play here:

1. Bump the actual `@headlessui/react` version.
2. Remove the `as={Fragment}` prop from the `<Transition>` and `<Transition.Child>` components. This is now the default behavior.
3. Replace the deprecated dot notation with concrete imported components.

These changes are optional because they work in a backwards compatible way. But since the `as={Fragment}` prop is now the default behavior, it's cleaner to remove it.

The dot notation will also still work, but since it's deprecated, your editor will show a warning, so let's clean it up as well.

Apart from these steps nothing else is changed nor required.
