### PR TITLE
Bump vue-tsc to v2 to fix crash with TypeScript v5.5

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -35,8 +35,8 @@ trait InstallsInertiaStacks
         if ($this->option('typescript')) {
             $this->updateNodePackages(function ($packages) {
                 return [
-                    'typescript' => '^5.0.2',
-                    'vue-tsc' => '^1.8.27',
+                    'typescript' => '^5.5.3',
+                    'vue-tsc' => '^2.0.24',
                 ] + $packages;
             });
         }


### PR DESCRIPTION
vue-tsc v1 crashes with typescript v5.5 and newer. Upgrade to vue-tsc v2 to fix.

https://github.com/vuejs/language-tools/issues/4484