### PR TITLE
[2.x] Replace `switch` with `match` in `dropdown.blade.php`

### DIFF
--- a/stubs/default/resources/views/components/dropdown.blade.php
+++ b/stubs/default/resources/views/components/dropdown.blade.php
@@ -1,24 +1,16 @@
 @props(['align' => 'right', 'width' => '48', 'contentClasses' => 'py-1 bg-white dark:bg-gray-700'])
 
 @php
-switch ($align) {
-    case 'left':
-        $alignmentClasses = 'ltr:origin-top-left rtl:origin-top-right start-0';
-        break;
-    case 'top':
-        $alignmentClasses = 'origin-top';
-        break;
-    case 'right':
-    default:
-        $alignmentClasses = 'ltr:origin-top-right rtl:origin-top-left end-0';
-        break;
-}
+$alignmentClasses = match ($align) {
+    'left' => 'ltr:origin-top-left rtl:origin-top-right start-0',
+    'top' => 'origin-top',
+    default => 'ltr:origin-top-right rtl:origin-top-left end-0',
+};
 
-switch ($width) {
-    case '48':
-        $width = 'w-48';
-        break;
-}
+$width = match ($width) {
+    '48' => 'w-48',
+    default => $width,
+};
 @endphp
 
 <div class="relative" x-data="{ open: false }" @click.outside="open = false" @close.stop="open = false">


### PR DESCRIPTION
Same logic, less code. Promotes modern PHP to more users.