### PR TITLE
Automatic insertion of settings required for front-end integration

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -66,6 +66,7 @@ trait InstallsApiStack
 
         // Cleaning...
         $this->removeScaffoldingUnnecessaryForApis();
+        $this->addFrontendUrlToAppConfig();
 
         $this->components->info('Breeze scaffolding installed successfully.');
     }

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -71,6 +71,31 @@ trait InstallsApiStack
     }
 
     /**
+     * Add frontend_url to app.php configuration file.
+     *
+     * @return void
+     */
+    protected function addFrontendUrlToAppConfig()
+    {
+        $appConfigPath = config_path('app.php');
+        $appConfig = file_get_contents($appConfigPath);
+
+        // Ensure the closing bracket is on a new line
+        if (strpos($appConfig, "\n];") === false) {
+            $appConfig = str_replace('];', "\n];", $appConfig);
+        }
+
+        // Insert frontend_url before the closing bracket
+        $updatedAppConfig = preg_replace(
+            '/\n\];/',
+            "\n    'frontend_url' => env('FRONTEND_URL', 'http://localhost:3000'),\n];",
+            $appConfig
+        );
+
+        file_put_contents($appConfigPath, $updatedAppConfig);
+    }
+
+    /**
      * Remove any application scaffolding that isn't needed for APIs.
      *
      * @return void


### PR DESCRIPTION
Dear Laravel Breeze Team, 

Hi, let me send my PR here.

# What I did
Fixed to automatically append the code needed for API integration with the frontend.
When the command `php artisan breeze:install` is executed, `'frontend_url' => env('FRONTEND_URL ', 'http://localhost:3000 '),` is appended to the end of `config/app.php`.

# Benefit for developers
In the current version, `FRONTEND_URL` is appended to the `.env` file when the `php artisan breeze:install` command is executed, but the code to read it `'frontend_url' => env('FRONTEND_URL ', 'http://localhost:3000'),` must be added manually to `config/app.php`.
This is not clearly stated in the tutorial in the official documentation (https://laravel.com/docs/11.x/starter-kits) and is kind for developers.

This fix solves them automatically, so developers can implement user and email authentication without hesitation.

Best regards,
Seito Hriguchi