### PR TITLE
Update User type to match db schema

### DIFF
--- a/stubs/inertia-react-ts/resources/js/types/index.d.ts
+++ b/stubs/inertia-react-ts/resources/js/types/index.d.ts
@@ -2,7 +2,7 @@ export interface User {
     id: number;
     name: string;
     email: string;
-    email_verified_at: string;
+    email_verified_at?: string;
 }
 
 export type PageProps<T extends Record<string, unknown> = Record<string, unknown>> = T & {

--- a/stubs/inertia-vue-ts/resources/js/types/index.d.ts
+++ b/stubs/inertia-vue-ts/resources/js/types/index.d.ts
@@ -2,7 +2,7 @@ export interface User {
     id: number;
     name: string;
     email: string;
-    email_verified_at: string;
+    email_verified_at?: string;
 }
 
 export type PageProps<T extends Record<string, unknown> = Record<string, unknown>> = T & {


### PR DESCRIPTION
In a default, fresh Laravel application, the `email_verified_at` is `nullable`. 

the type definition in Breeze does not match that of the db schema 

this PR simply updates the type definition in the react and vue TS starters to make that field nullable.