### PR TITLE
[2.x] Use Pest as default testing framework

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -391,7 +391,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
         $input->setOption('pest', select(
             label: 'Which testing framework do you prefer?',
             options: ['Pest', 'PHPUnit'],
-            default: $this->isUsingPest() ? 'Pest' : 'PHPUnit',
+            default: 'Pest',
         ) === 'Pest');
     }
 


### PR DESCRIPTION
Ensure `Pest` is the default selected testing framework when asking for missing arguments.