### PR TITLE
[2.x] Added `bun` & `deno` support to `flushNodeModules()`

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -275,6 +275,8 @@ class InstallCommand extends Command implements PromptsForMissingInput
             $files->deleteDirectory(base_path('node_modules'));
 
             $files->delete(base_path('yarn.lock'));
+            $files->delete(base_path('bun.lockb'));
+            $files->delete(base_path('deno.lock'));
             $files->delete(base_path('package-lock.json'));
         });
     }


### PR DESCRIPTION
`src/Console/installCommand.php`

-- before --
```php
protected static function flushNodeModules()
{
    tap(new Filesystem, function ($files) {
        $files->deleteDirectory(base_path('node_modules'));
        
        $files->delete(base_path('yarn.lock'));
        $files->delete(base_path('package-lock.json'));
    });
}
```

-- after --
```php
protected static function flushNodeModules()
{
    tap(new Filesystem, function ($files) {
        $files->deleteDirectory(base_path('node_modules'));
        
        $files->delete(base_path('yarn.lock'));
        $files->delete(base_path('bun.lockb'));
        $files->delete(base_path('deno.lock'));
        $files->delete(base_path('package-lock.json'));
    });
}
```