### PR TITLE
fix: add clearErrors on DeleteUserForm on closeModal function

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
@@ -42,7 +42,6 @@ export default function DeleteUserForm({ className = '' }: { className?: string 
         setConfirmingUserDeletion(false);
 
         clearErrors();
-
         reset();
     };
 

--- a/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
@@ -18,6 +18,7 @@ export default function DeleteUserForm({ className = '' }: { className?: string 
         processing,
         reset,
         errors,
+        clearErrors,
     } = useForm({
         password: '',
     });
@@ -39,6 +40,8 @@ export default function DeleteUserForm({ className = '' }: { className?: string 
 
     const closeModal = () => {
         setConfirmingUserDeletion(false);
+
+        clearErrors();
 
         reset();
     };

--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
@@ -42,7 +42,6 @@ export default function DeleteUserForm({ className = '' }) {
         setConfirmingUserDeletion(false);
 
         clearErrors();
-
         reset();
     };
 

--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
@@ -18,6 +18,7 @@ export default function DeleteUserForm({ className = '' }) {
         processing,
         reset,
         errors,
+        clearErrors,
     } = useForm({
         password: '',
     });
@@ -39,6 +40,8 @@ export default function DeleteUserForm({ className = '' }) {
 
     const closeModal = () => {
         setConfirmingUserDeletion(false);
+
+        clearErrors();
 
         reset();
     };

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -36,7 +36,6 @@ const closeModal = () => {
     confirmingUserDeletion.value = false;
 
     form.clearErrors();
-
     form.reset();
 };
 </script>

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -35,6 +35,8 @@ const deleteUser = () => {
 const closeModal = () => {
     confirmingUserDeletion.value = false;
 
+    form.clearErrors();
+
     form.reset();
 };
 </script>

--- a/stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -33,6 +33,8 @@ const deleteUser = () => {
 const closeModal = () => {
     confirmingUserDeletion.value = false;
 
+    form.clearErrors();
+
     form.reset();
 };
 </script>

--- a/stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -34,7 +34,6 @@ const closeModal = () => {
     confirmingUserDeletion.value = false;
 
     form.clearErrors();
-
     form.reset();
 };
 </script>


### PR DESCRIPTION
Closing `Modal` with validation errors, from `DeleteUserForm` component, will reset the password input but will **NOT** reset the input validation errors. 

Adding clearErrors on closeModal function will resolve this issue.

**Steps to reproduce:**

- Open Profile Page
- Click **Delete Account**
- Submit form with empty password input, appears validation error
- Click **Cancel** to close modal (input value will be cleared, **but validation error not**)
- Click **Delete Account** again, form will be empty but validation error will persist

**Changed files:**

- `stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx`
- `stubs/inertia-react/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx`
- `stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.vue`
- `stubs/inertia-vue/resources/js/Pages/Profile/Partials/DeleteUserForm.vue`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
