### PR TITLE
check for import.meta.env.SSR instead of import.meta.env.DEV to know…

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -379,12 +379,12 @@ trait InstallsInertiaStacks
                     root.render(<App {...props} />);
             EOT,
             <<<'EOT'
-                    if (!import.meta.env.SSR) {
-                        createRoot(el).render(<App {...props} />);
-                        return
+                    if (import.meta.env.SSR) {
+                        hydrateRoot(el, <App {...props} />);
                     }
 
-                    hydrateRoot(el, <App {...props} />);
+                    createRoot(el).render(<App {...props} />);
+                    return
             EOT,
             $path
         );

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -381,10 +381,10 @@ trait InstallsInertiaStacks
             <<<'EOT'
                     if (import.meta.env.SSR) {
                         hydrateRoot(el, <App {...props} />);
+                        return;
                     }
 
                     createRoot(el).render(<App {...props} />);
-                    return
             EOT,
             $path
         );

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -379,7 +379,7 @@ trait InstallsInertiaStacks
                     root.render(<App {...props} />);
             EOT,
             <<<'EOT'
-                    if (import.meta.env.DEV) {
+                    if (!import.meta.env.SSR) {
                         createRoot(el).render(<App {...props} />);
                         return
                     }

--- a/stubs/inertia-react-ts/resources/js/ssr.tsx
+++ b/stubs/inertia-react-ts/resources/js/ssr.tsx
@@ -14,6 +14,7 @@ createServer((page) =>
         title: (title) => `${title} - ${appName}`,
         resolve: (name) => resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx')),
         setup: ({ App, props }) => {
+            // @ts-expect-error
             global.route<RouteName> = (name, params, absolute) =>
                 route(name, params as any, absolute, {
                     // @ts-expect-error


### PR DESCRIPTION
… if CSR should hydrateRoot or createRoot

I had a bug when running inertia SSR with React.
It rendered the app two times because of the check on the import.meta.env.DEV, leading to a call to createRoot instead of hydrateRoot in the app.jsx file.

The fix now checks for the value of import.meta.env.SSR, provided by Vite.