### PR TITLE
[2.x] Add sonarlint suggestions to Typescript React Templates

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Components/ApplicationLogo.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/ApplicationLogo.tsx
@@ -1,6 +1,6 @@
 import { SVGAttributes } from 'react';
 
-export default function ApplicationLogo(props: SVGAttributes<SVGElement>) {
+export default function ApplicationLogo(props: Readonly<SVGAttributes<SVGElement>>) {
     return (
         <svg
             {...props}

--- a/stubs/inertia-react-ts/resources/js/Components/Checkbox.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Checkbox.tsx
@@ -3,7 +3,7 @@ import { InputHTMLAttributes } from 'react';
 export default function Checkbox({
     className = '',
     ...props
-}: InputHTMLAttributes<HTMLInputElement>) {
+}: Readonly<InputHTMLAttributes<HTMLInputElement>>) {
     return (
         <input
             {...props}

--- a/stubs/inertia-react-ts/resources/js/Components/DangerButton.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/DangerButton.tsx
@@ -5,7 +5,7 @@ export default function DangerButton({
     disabled,
     children,
     ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: Readonly<ButtonHTMLAttributes<HTMLButtonElement>>) {
     return (
         <button
             {...props}

--- a/stubs/inertia-react-ts/resources/js/Components/Dropdown.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Dropdown.tsx
@@ -1,6 +1,14 @@
-import { useState, createContext, useContext, PropsWithChildren, Dispatch, SetStateAction, useMemo } from 'react';
-import { Link, InertiaLinkProps } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
+import { InertiaLinkProps, Link } from '@inertiajs/react';
+import {
+    createContext,
+    Dispatch,
+    PropsWithChildren,
+    SetStateAction,
+    useContext,
+    useState,
+    useMemo,
+} from 'react';
 
 const DropDownContext = createContext<{
     open: boolean;
@@ -35,12 +43,26 @@ const Trigger = ({ children }: PropsWithChildren) => {
         <>
             <div onClick={toggleOpen}>{children}</div>
 
-            {open && <div className="fixed inset-0 z-40" onClick={() => setOpen(false)}></div>}
+            {open && (
+                <div
+                    className="fixed inset-0 z-40"
+                    onClick={() => setOpen(false)}
+                ></div>
+            )}
         </>
     );
 };
 
-const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-white dark:bg-gray-700', children }: PropsWithChildren<{ align?: 'left'|'right', width?: '48', contentClasses?: string }>) => {
+const Content = ({
+    align = 'right',
+    width = '48',
+    contentClasses = 'py-1 bg-white dark:bg-gray-700',
+    children,
+}: PropsWithChildren<{
+    align?: 'left' | 'right';
+    width?: '48';
+    contentClasses?: string;
+}>) => {
     const { open, setOpen } = useContext(DropDownContext);
 
     let alignmentClasses = 'origin-top';
@@ -84,12 +106,16 @@ const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-whit
     );
 };
 
-const DropdownLink = ({ className = '', children, ...props }: InertiaLinkProps) => {
+const DropdownLink = ({
+    className = '',
+    children,
+    ...props
+}: InertiaLinkProps) => {
     return (
         <Link
             {...props}
             className={
-                'block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out ' +
+                'block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800 ' +
                 className
             }
         >

--- a/stubs/inertia-react-ts/resources/js/Components/Dropdown.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/Dropdown.tsx
@@ -1,13 +1,6 @@
+import { useState, createContext, useContext, PropsWithChildren, Dispatch, SetStateAction, useMemo } from 'react';
+import { Link, InertiaLinkProps } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
-import { InertiaLinkProps, Link } from '@inertiajs/react';
-import {
-    createContext,
-    Dispatch,
-    PropsWithChildren,
-    SetStateAction,
-    useContext,
-    useState,
-} from 'react';
 
 const DropDownContext = createContext<{
     open: boolean;
@@ -26,8 +19,10 @@ const Dropdown = ({ children }: PropsWithChildren) => {
         setOpen((previousState) => !previousState);
     };
 
+    const contextValue = useMemo(() => ({ open, setOpen, toggleOpen }), [open, setOpen, toggleOpen]);
+
     return (
-        <DropDownContext.Provider value={{ open, setOpen, toggleOpen }}>
+        <DropDownContext.Provider value={contextValue}>
             <div className="relative">{children}</div>
         </DropDownContext.Provider>
     );
@@ -40,26 +35,12 @@ const Trigger = ({ children }: PropsWithChildren) => {
         <>
             <div onClick={toggleOpen}>{children}</div>
 
-            {open && (
-                <div
-                    className="fixed inset-0 z-40"
-                    onClick={() => setOpen(false)}
-                ></div>
-            )}
+            {open && <div className="fixed inset-0 z-40" onClick={() => setOpen(false)}></div>}
         </>
     );
 };
 
-const Content = ({
-    align = 'right',
-    width = '48',
-    contentClasses = 'py-1 bg-white dark:bg-gray-700',
-    children,
-}: PropsWithChildren<{
-    align?: 'left' | 'right';
-    width?: '48';
-    contentClasses?: string;
-}>) => {
+const Content = ({ align = 'right', width = '48', contentClasses = 'py-1 bg-white dark:bg-gray-700', children }: PropsWithChildren<{ align?: 'left'|'right', width?: '48', contentClasses?: string }>) => {
     const { open, setOpen } = useContext(DropDownContext);
 
     let alignmentClasses = 'origin-top';
@@ -77,44 +58,38 @@ const Content = ({
     }
 
     return (
-        <>
-            <Transition
-                show={open}
-                enter="transition ease-out duration-200"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="transition ease-in duration-75"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
+        <Transition
+            show={open}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+        >
+            <div
+                className={`absolute z-50 mt-2 rounded-md shadow-lg ${alignmentClasses} ${widthClasses}`}
+                onClick={() => setOpen(false)}
             >
                 <div
-                    className={`absolute z-50 mt-2 rounded-md shadow-lg ${alignmentClasses} ${widthClasses}`}
-                    onClick={() => setOpen(false)}
+                    className={
+                        `rounded-md ring-1 ring-black ring-opacity-5 ` +
+                        contentClasses
+                    }
                 >
-                    <div
-                        className={
-                            `rounded-md ring-1 ring-black ring-opacity-5 ` +
-                            contentClasses
-                        }
-                    >
-                        {children}
-                    </div>
+                    {children}
                 </div>
-            </Transition>
-        </>
+            </div>
+        </Transition>
     );
 };
 
-const DropdownLink = ({
-    className = '',
-    children,
-    ...props
-}: InertiaLinkProps) => {
+const DropdownLink = ({ className = '', children, ...props }: InertiaLinkProps) => {
     return (
         <Link
             {...props}
             className={
-                'block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800 ' +
+                'block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out ' +
                 className
             }
         >

--- a/stubs/inertia-react-ts/resources/js/Components/InputLabel.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/InputLabel.tsx
@@ -14,7 +14,7 @@ export default function InputLabel({
                 className
             }
         >
-            {value ? value : children}
+            {value ?? children}
         </label>
     );
 }

--- a/stubs/inertia-react-ts/resources/js/Components/PrimaryButton.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/PrimaryButton.tsx
@@ -5,7 +5,7 @@ export default function PrimaryButton({
     disabled,
     children,
     ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: Readonly<ButtonHTMLAttributes<HTMLButtonElement>>) {
     return (
         <button
             {...props}

--- a/stubs/inertia-react-ts/resources/js/Components/SecondaryButton.tsx
+++ b/stubs/inertia-react-ts/resources/js/Components/SecondaryButton.tsx
@@ -6,7 +6,7 @@ export default function SecondaryButton({
     disabled,
     children,
     ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: Readonly<ButtonHTMLAttributes<HTMLButtonElement>>) {
     return (
         <button
             {...props}


### PR DESCRIPTION
This pull request applies SonarLint suggestions to the TSX templates, including:
- Adding readonly to certain properties.
- Using useMemo in one instance to prevent unnecessary re-renders.
- Replacing a ternary operator with the nullish coalescing operator.
- Removing an empty parent element.

Suggestions to change certain elements to their interactable counterparts have not been implemented.

This pull request doesn't add much, but I’d appreciate any feedback.