### PR TITLE
Add hint to clarify how to use multiselect

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -402,7 +402,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
                     'typescript' => 'TypeScript',
                     'eslint' => 'ESLint with Prettier',
                 ],
-                hint: 'Use the space bar to select option(s).'
+                hint: 'Use the space bar to select options.'
             ))->each(fn ($option) => $input->setOption($option, true));
         } elseif (in_array($stack, ['blade', 'livewire', 'livewire-functional'])) {
             $input->setOption('dark', confirm(

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -395,7 +395,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
         if (in_array($stack, ['react', 'vue'])) {
             collect(multiselect(
-                label: 'Would you like any optional features?',
+                label: 'Would you like any optional features? Use space bar to select.',
                 options: [
                     'dark' => 'Dark mode',
                     'ssr' => 'Inertia SSR',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -395,13 +395,14 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
         if (in_array($stack, ['react', 'vue'])) {
             collect(multiselect(
-                label: 'Would you like any optional features? Use space bar to select.',
+                label: 'Would you like any optional features?',
                 options: [
                     'dark' => 'Dark mode',
                     'ssr' => 'Inertia SSR',
                     'typescript' => 'TypeScript',
                     'eslint' => 'ESLint with Prettier',
-                ]
+                ],
+                hint: 'Use the space bar to select option(s).'
             ))->each(fn ($option) => $input->setOption($option, true));
         } elseif (in_array($stack, ['blade', 'livewire', 'livewire-functional'])) {
             $input->setOption('dark', confirm(


### PR DESCRIPTION
Added a hint to clarify how to use the multi-select form option. 
<img width="469" alt="Screenshot 2024-09-24 at 1 39 46 PM" src="https://github.com/user-attachments/assets/e8ab02ad-52cc-434d-a5d6-cdcb518e63e5">.

I was confused myself and noticed other users have expressed confusion about how to select multi select boxes in terminal:
- https://github.com/laravel/prompts/pull/50
- https://github.com/laravel/prompts/issues/41