### PR TITLE
fix(redirect): Use frontend_url for redirection

### DIFF
--- a/stubs/api/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/stubs/api/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -15,7 +15,7 @@ class EmailVerificationNotificationController extends Controller
     public function store(Request $request): JsonResponse|RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended('/dashboard');
+            return redirect()->intended(config('app.frontend_url').'/dashboard');
         }
 
         $request->user()->sendEmailVerificationNotification();


### PR DESCRIPTION
Hello,

I found that this redirect triggered when the account is already validated when trying to send a validation email doesn't follow the same behavior as the others (for exemple [here](https://github.com/laravel/breeze/blob/2.x/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php#L19) and [here](https://github.com/laravel/breeze/blob/2.x/stubs/api/app/Http/Controllers/Auth/VerifyEmailController.php#L28))

An actual scenario that I came across : 
I use it only with API, but my frontend follow redirects.
I ask for a validation email, I open it in a new tab. I close the tab where I'm now logged-in. I go back to the tab where I asked for the email. Clicking again on the "Send email" should redirect me to /dashboard (using my frontend), but it actually redirects me to /dashboard with the URL of my api.

What do you think ?

Thanks.