### PR TITLE
[2.x] chore: text-input to use @disabled

### DIFF
--- a/stubs/default/resources/views/components/text-input.blade.php
+++ b/stubs/default/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input {{ $disabled ? 'disabled' : '' }} {{ $attributes->merge(['class' => 'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm']) }}>
+<input @disabled($disabled) {{ $attributes->merge(['class' => 'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm']) }}>


### PR DESCRIPTION
This pull request includes a small change to the `stubs/default/resources/views/components/text-input.blade.php` file. The change simplifies the way the `disabled` attribute is handled in the input element.

* [`stubs/default/resources/views/components/text-input.blade.php`](diffhunk://#diff-5c63ea3ffeb9083d95196c6014dbc91100a01ca21ca850ec29c1a05131c6cab5L3-R3): Replaced the ternary operator with the `@disabled` directive for handling the `disabled` attribute in the input element.