### PR TITLE
Update Login/Register form to look more modern

### DIFF
--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -1,46 +1,51 @@
 <x-guest-layout>
     <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
-
+ 
     <form method="POST" action="{{ route('login') }}">
         @csrf
-
+        <!-- Heading -->
+        <div class="flex justify-center items-center mb-0.5 text-white flex-col flex-wrap">
+        <h1 class="font-bold text-2xl">Login</h1>
+            <span class="text-sm text-gray-600 dark:text-gray-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"> {{ __('Don\'t have an account? ') }}<a class="underline font-semibold text-gray-500 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100" href="{{ route('register') }}">{{ __('Register!') }}</a></span>
+ 
+        </div>
+ 
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
             <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
-
+ 
         <!-- Password -->
         <div class="mt-4">
             <x-input-label for="password" :value="__('Password')" />
-
+ 
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
                             name="password"
                             required autocomplete="current-password" />
-
+ 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
-
+ 
         <!-- Remember Me -->
-        <div class="block mt-4">
-            <label for="remember_me" class="inline-flex items-center">
+        <div class="mt-4 flex items-center justify-between">
+            <label for="remember_me">
                 <input id="remember_me" type="checkbox" class="rounded dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800" name="remember">
                 <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">{{ __('Remember me') }}</span>
             </label>
-        </div>
-
-        <div class="flex items-center justify-end mt-4">
             @if (Route::has('password.request'))
                 <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
             @endif
-
-            <x-primary-button class="ms-3">
-                {{ __('Log in') }}
+        </div>
+ 
+        <div class="block mt-4 w-full">
+            <x-primary-button class="w-full justify-center">
+                {{ __('Login') }}
             </x-primary-button>
         </div>
     </form>

--- a/stubs/default/resources/views/auth/register.blade.php
+++ b/stubs/default/resources/views/auth/register.blade.php
@@ -1,50 +1,51 @@
 <x-guest-layout>
     <form method="POST" action="{{ route('register') }}">
         @csrf
-
+        <!-- Heading -->
+        <div class="flex justify-center items-center mb-0.5 text-white flex-col flex-wrap">
+            <h1 class="font-bold text-2xl">Register</h1>
+            <span class="text-sm text-gray-600 dark:text-gray-400 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"> {{ __('Already have an account? ') }}<a class="underline font-semibold text-gray-500 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100" href="{{ route('login') }}">{{ __('Login!') }}</a></span>
+        </div>
+ 
         <!-- Name -->
         <div>
             <x-input-label for="name" :value="__('Name')" />
             <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
-
+ 
         <!-- Email Address -->
         <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />
             <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
-
+ 
         <!-- Password -->
         <div class="mt-4">
             <x-input-label for="password" :value="__('Password')" />
-
+ 
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
                             name="password"
                             required autocomplete="new-password" />
-
+ 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
-
+ 
         <!-- Confirm Password -->
         <div class="mt-4">
             <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
-
+ 
             <x-text-input id="password_confirmation" class="block mt-1 w-full"
                             type="password"
                             name="password_confirmation" required autocomplete="new-password" />
-
+ 
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
         </div>
-
-        <div class="flex items-center justify-end mt-4">
-            <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('login') }}">
-                {{ __('Already registered?') }}
-            </a>
-
-            <x-primary-button class="ms-4">
+ 
+        <div class="block mt-4 w-full">
+            <x-primary-button class="w-full justify-center">
                 {{ __('Register') }}
             </x-primary-button>
         </div>


### PR DESCRIPTION
This makes a few changes to the login and register form including the following:

- "Don't have an account" yet button on login
- Make the action button full width
- Add a heading to both pages

This aims to make both forms look more modern and easier on the eye. 

Preview: 

<img width="881" alt="Bildschirmfoto 2024-10-11 um 12 25 20" src="https://github.com/user-attachments/assets/21ebefd2-b13e-4341-9643-a6f12c969377">
<img width="687" alt="Bildschirmfoto 2024-10-11 um 12 25 08" src="https://github.com/user-attachments/assets/48393f7f-3616-478d-844a-df733415fedd">

