### PR TITLE
[2.x] Fixed TypeScript Errors in React SSR Setup with Ziggy Props when Builds

### DIFF
--- a/stubs/inertia-react-ts/resources/js/ssr.tsx
+++ b/stubs/inertia-react-ts/resources/js/ssr.tsx
@@ -22,7 +22,9 @@ createServer((page) =>
             // @ts-expect-error
             global.route<RouteName> = (name, params, absolute) =>
                 route(name, params as any, absolute, {
+                    // @ts-expect-error
                     ...page.props.ziggy,
+                    // @ts-expect-error
                     location: new URL(page.props.ziggy.location),
                 });
             /* eslint-enable */


### PR DESCRIPTION
This PR fixes TypeScript errors encountered during the SSR build process for React. Specifically, two errors were addressed:
1. `Spread types may only be created from object types` due to `page.props.ziggy` being of type `unknown`.
2. TypeScript type issue when trying to access `page.props.ziggy.location`.

The updated code includes `@ts-expect-error` directives to bypass the type errors temporarily and allow successful builds.

A screenshot of the errors is attached for reference.
![image](https://github.com/user-attachments/assets/a8fb2ae3-7bdb-4503-80d2-c2cbecdefe27)
