### PR TITLE
[2.x] Add frontend_url to App Config in API Stack

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -47,6 +47,11 @@ trait InstallsApiStack
         // Configuration...
         $files->copyDirectory(__DIR__.'/../../stubs/api/config', config_path());
 
+        file_put_contents(
+            base_path('config/app.php'),
+            str_replace("'url' => env('APP_URL', 'http://localhost'),", "'url' => env('APP_URL', 'http://localhost'),".PHP_EOL.PHP_EOL."    'frontend_url' => env('FRONTEND_URL', 'http://localhost:3000'),", file_get_contents(base_path('config/app.php')))
+        );
+
         // Environment...
         if (! $files->exists(base_path('.env'))) {
             copy(base_path('.env.example'), base_path('.env'));


### PR DESCRIPTION
Some files in the project use app.frontend_url (e.g., [this search result](https://github.com/search?q=repo%3Alaravel%2Fbreeze+app.frontend_url&type=code)), but it was missing from the config/app.php file in the API stack. I have added the feature by including the frontend_url in the app config.