### PR TITLE
fix(ts): remove redundant @ts-expect-error directives in SSR route setup

### DIFF
--- a/stubs/inertia-react-ts/resources/js/ssr.tsx
+++ b/stubs/inertia-react-ts/resources/js/ssr.tsx
@@ -22,9 +22,7 @@ createServer((page) =>
             // @ts-expect-error
             global.route<RouteName> = (name, params, absolute) =>
                 route(name, params as any, absolute, {
-                    // @ts-expect-error
                     ...page.props.ziggy,
-                    // @ts-expect-error
                     location: new URL(page.props.ziggy.location),
                 });
             /* eslint-enable */


### PR DESCRIPTION
The `@ts-expect-error` directives were unnecessary for the Ziggy props and location assignments within the global route function, as TypeScript can properly infer these types.

<img width="1502" alt="Screenshot 2024-11-02 at 12 38 36" src="https://github.com/user-attachments/assets/4ff251e1-338b-4b1e-a785-43707684e149">
