### PR TITLE
Convert array to single line format

### DIFF
--- a/stubs/default/vite.config.js
+++ b/stubs/default/vite.config.js
@@ -4,10 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: [
-                'resources/css/app.css',
-                'resources/js/app.js',
-            ],
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
To prevent useless commit on default Laravel installations.

I don't know if this change could break something, maybe the lack of final comma...
Could it be better to do the opposite change on laravel/laravel?