### PR TITLE
[2.x] Replace `Rule` with `ValidationRule`

### DIFF
--- a/stubs/api/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/api/app/Http/Requests/Auth/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/stubs/default/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/default/app/Http/Requests/Auth/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
+++ b/stubs/default/app/Http/Requests/ProfileUpdateRequest.php
@@ -11,7 +11,7 @@ class ProfileUpdateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR replaces `\Illuminate\Contracts\Validation\Rule` with `\Illuminate\Contracts\Validation\ValidationRule` in form requests since `\Illuminate\Contracts\Validation\Rule` is deprecated.

It also specifies the array type to prevent PHPStan errors with level 6.

This is aligned with the framework stub.
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Console/stubs/request.stub