### PR TITLE
fix: resolve autocomplete attribute on email input

### DIFF
--- a/stubs/default/resources/views/auth/login.blade.php
+++ b/stubs/default/resources/views/auth/login.blade.php
@@ -8,7 +8,7 @@
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/default/resources/views/auth/register.blade.php
+++ b/stubs/default/resources/views/auth/register.blade.php
@@ -12,7 +12,7 @@
         <!-- Email Address -->
         <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/default/resources/views/auth/reset-password.blade.php
+++ b/stubs/default/resources/views/auth/reset-password.blade.php
@@ -8,7 +8,7 @@
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $request->email)" required autofocus autocomplete="username" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $request->email)" required autofocus autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/default/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/stubs/default/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -25,7 +25,7 @@
 
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required autocomplete="username" />
+            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required autocomplete="email" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
             @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())

--- a/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
@@ -48,7 +48,7 @@ export default function Login({
                         name="email"
                         value={data.email}
                         className="mt-1 block w-full"
-                        autoComplete="username"
+                        autoComplete="email"
                         isFocused={true}
                         onChange={(e) => setData('email', e.target.value)}
                     />

--- a/stubs/inertia-react-ts/resources/js/Pages/Auth/Register.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Auth/Register.tsx
@@ -53,7 +53,7 @@ export default function Register() {
                         name="email"
                         value={data.email}
                         className="mt-1 block w-full"
-                        autoComplete="username"
+                        autoComplete="email"
                         onChange={(e) => setData('email', e.target.value)}
                         required
                     />

--- a/stubs/inertia-react-ts/resources/js/Pages/Auth/ResetPassword.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Auth/ResetPassword.tsx
@@ -42,7 +42,7 @@ export default function ResetPassword({
                         name="email"
                         value={data.email}
                         className="mt-1 block w-full"
-                        autoComplete="username"
+                        autoComplete="email"
                         onChange={(e) => setData('email', e.target.value)}
                     />
 

--- a/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
@@ -68,7 +68,7 @@ export default function UpdateProfileInformation({
                         value={data.email}
                         onChange={(e) => setData('email', e.target.value)}
                         required
-                        autoComplete="username"
+                        autoComplete="email"
                     />
 
                     <InputError className="mt-2" message={errors.email} />

--- a/stubs/inertia-react/resources/js/Pages/Auth/Login.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Auth/Login.jsx
@@ -41,7 +41,7 @@ export default function Login({ status, canResetPassword }) {
                         name="email"
                         value={data.email}
                         className="mt-1 block w-full"
-                        autoComplete="username"
+                        autoComplete="email"
                         isFocused={true}
                         onChange={(e) => setData('email', e.target.value)}
                     />

--- a/stubs/inertia-react/resources/js/Pages/Auth/Register.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Auth/Register.jsx
@@ -52,7 +52,7 @@ export default function Register() {
                         name="email"
                         value={data.email}
                         className="mt-1 block w-full"
-                        autoComplete="username"
+                        autoComplete="email"
                         onChange={(e) => setData('email', e.target.value)}
                         required
                     />

--- a/stubs/inertia-react/resources/js/Pages/Auth/ResetPassword.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Auth/ResetPassword.jsx
@@ -35,7 +35,7 @@ export default function ResetPassword({ token, email }) {
                         name="email"
                         value={data.email}
                         className="mt-1 block w-full"
-                        autoComplete="username"
+                        autoComplete="email"
                         onChange={(e) => setData('email', e.target.value)}
                     />
 

--- a/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/stubs/inertia-react/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -63,7 +63,7 @@ export default function UpdateProfileInformation({
                         value={data.email}
                         onChange={(e) => setData('email', e.target.value)}
                         required
-                        autoComplete="username"
+                        autoComplete="email"
                     />
 
                     <InputError className="mt-2" message={errors.email} />

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/ForgotPassword.vue
@@ -47,7 +47,7 @@ const submit = () => {
                     v-model="form.email"
                     required
                     autofocus
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/Login.vue
@@ -46,7 +46,7 @@ const submit = () => {
                     v-model="form.email"
                     required
                     autofocus
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/Register.vue
@@ -52,7 +52,7 @@ const submit = () => {
                     class="mt-1 block w-full"
                     v-model="form.email"
                     required
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue-ts/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Auth/ResetPassword.vue
@@ -42,7 +42,7 @@ const submit = () => {
                     v-model="form.email"
                     required
                     autofocus
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia-vue-ts/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -59,7 +59,7 @@ const form = useForm({
                     class="mt-1 block w-full"
                     v-model="form.email"
                     required
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/ForgotPassword.vue
@@ -49,7 +49,7 @@ const submit = () => {
                     v-model="form.email"
                     required
                     autofocus
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/Login.vue
@@ -48,7 +48,7 @@ const submit = () => {
                     v-model="form.email"
                     required
                     autofocus
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/Register.vue
@@ -50,7 +50,7 @@ const submit = () => {
                     class="mt-1 block w-full"
                     v-model="form.email"
                     required
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Auth/ResetPassword.vue
@@ -46,7 +46,7 @@ const submit = () => {
                     v-model="form.email"
                     required
                     autofocus
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/inertia-vue/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia-vue/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -63,7 +63,7 @@ const form = useForm({
                     class="mt-1 block w-full"
                     v-model="form.email"
                     required
-                    autocomplete="username"
+                    autocomplete="email"
                 />
 
                 <InputError class="mt-2" :message="form.errors.email" />

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/login.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/login.blade.php
@@ -30,7 +30,7 @@ $login = function () {
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="form.email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="username" />
+            <x-text-input wire:model="form.email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="email" />
             <x-input-error :messages="$errors->get('form.email')" class="mt-2" />
         </div>
 

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/register.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/register.blade.php
@@ -51,7 +51,7 @@ $register = function () {
         <!-- Email Address -->
         <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="username" />
+            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/livewire-functional/resources/views/livewire/pages/auth/reset-password.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/pages/auth/reset-password.blade.php
@@ -66,7 +66,7 @@ $resetPassword = function () {
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="username" />
+            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire-functional/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -68,7 +68,7 @@ $sendVerification = function () {
 
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="email" id="email" name="email" type="email" class="mt-1 block w-full" required autocomplete="username" />
+            <x-text-input wire:model="email" id="email" name="email" type="email" class="mt-1 block w-full" required autocomplete="email" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
             @if (auth()->user() instanceof MustVerifyEmail && ! auth()->user()->hasVerifiedEmail())

--- a/stubs/livewire/resources/views/livewire/pages/auth/login.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/login.blade.php
@@ -32,7 +32,7 @@ new #[Layout('layouts.guest')] class extends Component
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="form.email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="username" />
+            <x-text-input wire:model="form.email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="email" />
             <x-input-error :messages="$errors->get('form.email')" class="mt-2" />
         </div>
 

--- a/stubs/livewire/resources/views/livewire/pages/auth/register.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/register.blade.php
@@ -48,7 +48,7 @@ new #[Layout('layouts.guest')] class extends Component
         <!-- Email Address -->
         <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="username" />
+            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/livewire/resources/views/livewire/pages/auth/reset-password.blade.php
+++ b/stubs/livewire/resources/views/livewire/pages/auth/reset-password.blade.php
@@ -74,7 +74,7 @@ new #[Layout('layouts.guest')] class extends Component
         <!-- Email Address -->
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="username" />
+            <x-text-input wire:model="email" id="email" class="block mt-1 w-full" type="email" name="email" required autofocus autocomplete="email" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 

--- a/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -82,7 +82,7 @@ new class extends Component
 
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input wire:model="email" id="email" name="email" type="email" class="mt-1 block w-full" required autocomplete="username" />
+            <x-text-input wire:model="email" id="email" name="email" type="email" class="mt-1 block w-full" required autocomplete="email" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
             @if (auth()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! auth()->user()->hasVerifiedEmail())


### PR DESCRIPTION
This PR corrects the autocomplete attribute on the email input in Laravel Breeze from "username" to "email", enhancing autofill accuracy and user experience.