### PR TITLE
Fix typescript version

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -35,7 +35,7 @@ trait InstallsInertiaStacks
         if ($this->option('typescript')) {
             $this->updateNodePackages(function ($packages) {
                 return [
-                    'typescript' => '^5.5.3',
+                    'typescript' => '^5.6.3',
                     'vue-tsc' => '^2.0.24',
                 ] + $packages;
             });


### PR DESCRIPTION
When I run npm run build with vue & inertia stack and typescript, I get this error, 

![image](https://github.com/user-attachments/assets/c9e01940-92da-4ed8-80ef-816dcfe0f3b9)

The fix is simply to use typescript ^5.6.

My node version: v22.12.0
My npm version: 10.9.0