### PR TITLE
[2.x] Remove tailwind config files on api stack

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -83,6 +83,7 @@ trait InstallsApiStack
         $files->delete(base_path('package.json'));
         $files->delete(base_path('vite.config.js'));
         $files->delete(base_path('tailwind.config.js'));
+        $files->delete(base_path('postcss.config.js'));
 
         // Remove Laravel "welcome" view...
         $files->delete(resource_path('views/welcome.blade.php'));

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -82,6 +82,7 @@ trait InstallsApiStack
         // Remove frontend related files...
         $files->delete(base_path('package.json'));
         $files->delete(base_path('vite.config.js'));
+        $files->delete(base_path('tailwind.config.js'));
 
         // Remove Laravel "welcome" view...
         $files->delete(resource_path('views/welcome.blade.php'));


### PR DESCRIPTION
I just generated a new application with the API-only breeze option. I find out that there is tailwind.config.js & postcss.config.js file. However, in the API projects, there is no need for TailwindCSS configuration.
