### PR TITLE
[2.x] Remove redundant `.d.ts` inclusion from `tsconfig.json`

### DIFF
--- a/stubs/inertia-vue-ts/tsconfig.json
+++ b/stubs/inertia-vue-ts/tsconfig.json
@@ -16,5 +16,5 @@
             "ziggy-js": ["./vendor/tightenco/ziggy"]
         }
     },
-    "include": ["resources/js/**/*.ts", "resources/js/**/*.d.ts", "resources/js/**/*.vue"]
+    "include": ["resources/js/**/*.ts", "resources/js/**/*.vue"]
 }


### PR DESCRIPTION
Removed `resources/js/**/*.d.ts` from the `include` array in `tsconfig.json` since `.d.ts` files are automatically included with `.ts` files. 