### PR TITLE
[2.x] add types to `useForm` in `Login.tsx`

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
@@ -8,7 +8,11 @@ import TextInput from '@/Components/TextInput';
 import { Head, Link, useForm } from '@inertiajs/react';
 
 export default function Login({ status, canResetPassword }: { status?: string, canResetPassword: boolean }) {
-    const { data, setData, post, processing, errors, reset } = useForm({
+    const { data, setData, post, processing, errors, reset } = useForm<{
+        email: string;
+        password: string;
+        remember: boolean;
+    }>({
         email: '',
         password: '',
         remember: false,


### PR DESCRIPTION

This PR adds type definitions to the `useForm` props in `Login.tsx` for the React Typescript stack, which fixes the problem with [these recent tests failing](https://github.com/laravel/breeze/actions/workflows/tests.yml?query=branch%3A2.x)