### PR TITLE
[2.x] Unpin typescript version for Inertia Vue stack

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -35,7 +35,7 @@ trait InstallsInertiaStacks
         if ($this->option('typescript')) {
             $this->updateNodePackages(function ($packages) {
                 return [
-                    'typescript' => '~5.5.3',
+                    'typescript' => '^5.6.3',
                     'vue-tsc' => '^2.0.24',
                 ] + $packages;
             });


### PR DESCRIPTION
As mentioned in https://github.com/laravel/breeze/pull/443, typescript version can be unpinned again once the issue in `vue-tsc` has been resolved and released, which is already the case now: https://github.com/vuejs/language-tools/issues/5018#issuecomment-2560359302.