### PR TITLE
[2.x] Add pagination type definitions

### DIFF
--- a/stubs/inertia-react-ts/resources/js/types/index.d.ts
+++ b/stubs/inertia-react-ts/resources/js/types/index.d.ts
@@ -6,9 +6,31 @@ export interface User {
 }
 
 export type PageProps<
-    T extends Record<string, unknown> = Record<string, unknown>,
+    T extends Record<string, unknown> = Record<string, unknown>
 > = T & {
     auth: {
         user: User;
     };
+};
+
+export type PaginationLink = {
+    url: string | null;
+    label: string;
+    active: boolean;
+};
+
+export type Pagination<T> = {
+    data: Array<T>;
+    links: Array<PaginationLink>;
+    path: string;
+    from: number;
+    to: number;
+    total: number;
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    first_page_url: string;
+    last_page_url: string;
+    next_page_url: string | null;
+    prev_page_url: string | null;
 };

--- a/stubs/inertia-vue-ts/resources/js/types/index.d.ts
+++ b/stubs/inertia-vue-ts/resources/js/types/index.d.ts
@@ -6,9 +6,31 @@ export interface User {
 }
 
 export type PageProps<
-    T extends Record<string, unknown> = Record<string, unknown>,
+    T extends Record<string, unknown> = Record<string, unknown>
 > = T & {
     auth: {
         user: User;
     };
+};
+
+export type PaginationLink = {
+    url: string | null;
+    label: string;
+    active: boolean;
+};
+
+export type Pagination<T> = {
+    data: Array<T>;
+    links: Array<PaginationLink>;
+    path: string;
+    from: number;
+    to: number;
+    total: number;
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    first_page_url: string;
+    last_page_url: string;
+    next_page_url: string | null;
+    prev_page_url: string | null;
 };


### PR DESCRIPTION
This PR adds pagination type definitions to both React and Vue Typescript flavors for Inertia. It aims to simplify how pagination objects are imported into Inertia projects from the backend.

Example in React:
```ts
// imports...

export default function Todos({ pagination }: PageProps<{ pagination: Pagination<Todo> }>) {
    return (
        <>
            {/* ... */}
        </>
    );
}
```  
