### PR TITLE
[2.x] Give users the option to keep js/css when installing the API stack

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -35,6 +35,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
                             {--ssr : Indicates if Inertia SSR support should be installed}
                             {--typescript : Indicates if TypeScript is preferred for the Inertia stack}
                             {--eslint : Indicates if ESLint with Prettier should be installed}
+                            {--remove-scaffolding : Indicates if default scaffolding should be removed with the API stack}
                             {--composer=global : Absolute path to the Composer binary which should be used to install packages}';
 
     /**
@@ -412,6 +413,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
             $input->setOption('dark', confirm(
                 label: 'Would you like dark mode support?',
                 default: false
+            ));
+        } elseif ($stack === 'api') {
+            $input->setOption('remove-scaffolding', confirm(
+                label: 'Would you like remove any unnecessary frontend (css, js, etc) scaffolding?',
             ));
         }
 

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -65,7 +65,9 @@ trait InstallsApiStack
         $files->delete(base_path('tests/Feature/Auth/PasswordConfirmationTest.php'));
 
         // Cleaning...
-        $this->removeScaffoldingUnnecessaryForApis();
+        if ($this->option('remove-scaffolding')) {
+            $this->removeScaffoldingUnnecessaryForApis();
+        }
 
         $this->components->info('Breeze scaffolding installed successfully.');
     }


### PR DESCRIPTION
Give users the option to keep js/css when installing the API stack.

For example, it's often a case where I'll want to add Auth features, but I've already started working on my frontend, I just don't want to implement the full Breeze stack for whatever reason.