### PR TITLE
fix: resolve type error in 'setData' for 'remember' parameter

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
@@ -17,7 +17,7 @@ export default function Login({
     const { data, setData, post, processing, errors, reset } = useForm({
         email: '',
         password: '',
-        remember: false,
+        remember: false as boolean,
     });
 
     const submit: FormEventHandler = (e) => {


### PR DESCRIPTION
Fixed a type error in Login.tsx (line 81) where setData was being called with a boolean value (e.target.checked) for the remember parameter, which expected a value of type false.

Solution: Adjusted the logic or type definition to ensure compatibility between the value passed (boolean) and the expected type for the remember parameter.


`
resources/js/Pages/Auth/Login.tsx:81:53 - error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'false'.
`

81                                 setData('remember', e.target.checked)`
