### PR TITLE
Remove install middleware alias 'verified' for API stack

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -24,10 +24,6 @@ trait InstallsApiStack
         // Middleware...
         $files->copyDirectory(__DIR__.'/../../stubs/api/app/Http/Middleware', app_path('Http/Middleware'));
 
-        $this->installMiddlewareAliases([
-            'verified' => '\App\Http\Middleware\EnsureEmailIsVerified::class',
-        ]);
-
         $this->installMiddleware([
             '\Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class',
         ], 'api', 'prepend');


### PR DESCRIPTION
This middleware is not utilized at any point within the API stack in the files the package installs. 
Perhaps the `EnsureEmailIsVerified` middleware class itself should not be copied either.