### PR TITLE
Fix tsc error in Pages/Auth/Login.tsx on fresh install

### DIFF
--- a/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
+++ b/stubs/inertia-react-ts/resources/js/Pages/Auth/Login.tsx
@@ -17,7 +17,7 @@ export default function Login({
     const { data, setData, post, processing, errors, reset } = useForm({
         email: '',
         password: '',
-        remember: false,
+        remember: false as boolean,
     });
 
     const submit: FormEventHandler = (e) => {


### PR DESCRIPTION
Typescript treats the `remember: false` as a literal type in the useForm call, which makes `tsc` fail when the checkbox calls `setData` with a boolean.

This happens on a fresh install:
- Laravel Installer 5.11.1
- Composer version 2.8.4
- Typescript 5.0.2
- "aravel/breeze 2.3.2

This commit tells typescript to treat `false` as a boolean, which fixes the `tsc` error and makes `npm run build` pass
