### PR TITLE
Add test for redirect on `verification.notice` route for verified user

### DIFF
--- a/stubs/default/pest-tests/Feature/Auth/EmailVerificationTest.php
+++ b/stubs/default/pest-tests/Feature/Auth/EmailVerificationTest.php
@@ -44,3 +44,12 @@ test('email is not verified with invalid hash', function () {
 
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });
+
+test('email verification screen redirects for verified user', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/verify-email');
+
+    $response->assertRedirect(route('dashboard'));
+});
+


### PR DESCRIPTION
An already verified user visiting the `verification.notice` route is redirected to the dashboard.

This occurs on line 19 in [stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationPromptController.php](https://github.com/laravel/breeze/blob/2.x/stubs/inertia-common/app/Http/Controllers/Auth/EmailVerificationPromptController.php) and line 18 in [stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php](https://github.com/laravel/breeze/blob/2.x/stubs/default/app/Http/Controllers/Auth/EmailVerificationPromptController.php).

This functionality does not seem to be tested.

This pull request adds a test for the path.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
