### PR TITLE
Add test for redirect on `verification.verify` route for verified user

### DIFF
--- a/stubs/default/pest-tests/Feature/Auth/EmailVerificationTest.php
+++ b/stubs/default/pest-tests/Feature/Auth/EmailVerificationTest.php
@@ -31,6 +31,24 @@ test('email can be verified', function () {
     $response->assertRedirect(route('dashboard', absolute: false).'?verified=1');
 });
 
+test('email can be verified by already verified user', function () {
+    $user = User::factory()->create();
+
+    Event::fake();
+
+    $verificationUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1($user->email)]
+    );
+
+    $response = $this->actingAs($user)->get($verificationUrl);
+
+    Event::assertNotDispatched(Verified::class);
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
+    $response->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
+});
+
 test('email is not verified with invalid hash', function () {
     $user = User::factory()->unverified()->create();
 


### PR DESCRIPTION
An already verified user visiting the `verification.verify` route is redirected to the dashboard without dispatching the `Verified` event.

This occurs on line 18 in [stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php](https://github.com/laravel/breeze/blob/2.x/stubs/default/app/Http/Controllers/Auth/VerifyEmailController.php) and line 18 in [stubs/inertia-common/app/Http/Controllers/Auth/VerifyEmailController.php](https://github.com/laravel/breeze/blob/2.x/stubs/inertia-common/app/Http/Controllers/Auth/VerifyEmailController.php).

This functionality does not seem to be tested.

This pull request adds a test for the path.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
