### PR TITLE
[2.x] [API stack] Add `APP_URL` and `FRONTEND_URL` to `.env.example`

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -52,10 +52,14 @@ trait InstallsApiStack
             copy(base_path('.env.example'), base_path('.env'));
         }
 
-        file_put_contents(
-            base_path('.env'),
-            preg_replace('/APP_URL=(.*)/', 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000', file_get_contents(base_path('.env')))
-        );
+        foreach (['.env', '.env.example'] as $envFile) {
+            $envPath = base_path($envFile);
+            $envContent = file_get_contents($envPath);
+            if (! empty($envContent)) {
+                $envContent = preg_replace('/APP_URL=.*/', 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000', $envContent);
+                file_put_contents($envPath, $envContent);
+            }
+        }
 
         // Tests...
         if (! $this->installTests()) {


### PR DESCRIPTION
Please review #466 first.

Updates `.env.example` with `APP_URL=http://localhost:8000` and `FRONTEND_URL=http://localhost:3000`, in addition to the changes made to `.env` when installing the API stack.

Since the `.env` file is typically not committed, this ensures that `.env.example` contains the necessary environment variables for consistency when setting up the project.

Note: The install script already assumes that `.env.example` exists.