### PR TITLE
[2.x] [API stack] Remove `VITE_APP_NAME` from `.env` and `.env.example`

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -52,10 +52,14 @@ trait InstallsApiStack
             copy(base_path('.env.example'), base_path('.env'));
         }
 
-        file_put_contents(
-            base_path('.env'),
-            preg_replace('/APP_URL=(.*)/', 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000', file_get_contents(base_path('.env')))
-        );
+        foreach (['.env', '.env.example'] as $envFile) {
+            $envPath = base_path($envFile);
+            $envContent = file_get_contents($envPath);
+            if (! empty($envContent)) {
+                $envContent = preg_replace('/APP_URL=.*/', 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000', $envContent);
+                file_put_contents($envPath, $envContent);
+            }
+        }
 
         // Tests...
         if (! $this->installTests()) {

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -57,6 +57,7 @@ trait InstallsApiStack
             $envContent = file_get_contents($envPath);
             if (! empty($envContent)) {
                 $envContent = preg_replace('/APP_URL=.*/', 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000', $envContent);
+                $envContent = preg_replace('/VITE_APP_NAME=.*\n\n?/', '', $envContent);
                 file_put_contents($envPath, $envContent);
             }
         }


### PR DESCRIPTION
Please review #466 first.

Removes the `VITE_APP_NAME="${APP_NAME}"` line from both the `.env` and `.env.example` files, since Vite not used in the API stack.

This PR depends on #463.
