### PR TITLE
[2.x] [API stack] Improve installation for Sail projects and ensure consistency in env files

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -68,6 +68,9 @@ trait InstallsApiStack
             $envContent = file_get_contents($envPath);
             if (! empty($envContent)) {
                 $envVars = 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000';
+                if ($isSail) {
+                    $envVars = 'APP_PORT=8000'.PHP_EOL.$envVars;
+                }
                 $envContent = preg_replace('/APP_URL=.*/', $envVars, $envContent);
                 $envContent = preg_replace('/VITE_APP_NAME=.*\n\n?/', '', $envContent);
                 file_put_contents($envPath, $envContent);

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -69,6 +69,7 @@ trait InstallsApiStack
             if (! empty($envContent)) {
                 $envVars = 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000';
                 $envContent = preg_replace('/APP_URL=.*/', $envVars, $envContent);
+                $envContent = preg_replace('/VITE_APP_NAME=.*\n\n?/', '', $envContent);
                 file_put_contents($envPath, $envContent);
             }
         }

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -47,6 +47,17 @@ trait InstallsApiStack
         // Configuration...
         $files->copyDirectory(__DIR__.'/../../stubs/api/config', config_path());
 
+        // Sail...
+        $dockerComposePath = base_path('docker-compose.yml');
+        $isSail = $files->exists($dockerComposePath);
+        if ($isSail) {
+            $dockerComposeContent = file_get_contents($dockerComposePath);
+            if (! empty($dockerComposeContent)) {
+                $dockerComposeContent = preg_replace('/\s*- \'\${VITE_PORT:-5173}:\${VITE_PORT:-5173}\'/', '', $dockerComposeContent);
+                file_put_contents($dockerComposePath, $dockerComposeContent);
+            }
+        }
+
         // Environment...
         if (! $files->exists(base_path('.env'))) {
             copy(base_path('.env.example'), base_path('.env'));

--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -63,10 +63,15 @@ trait InstallsApiStack
             copy(base_path('.env.example'), base_path('.env'));
         }
 
-        file_put_contents(
-            base_path('.env'),
-            preg_replace('/APP_URL=(.*)/', 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000', file_get_contents(base_path('.env')))
-        );
+        foreach (['.env', '.env.example'] as $envFile) {
+            $envPath = base_path($envFile);
+            $envContent = file_get_contents($envPath);
+            if (! empty($envContent)) {
+                $envVars = 'APP_URL=http://localhost:8000'.PHP_EOL.'FRONTEND_URL=http://localhost:3000';
+                $envContent = preg_replace('/APP_URL=.*/', $envVars, $envContent);
+                file_put_contents($envPath, $envContent);
+            }
+        }
 
         // Tests...
         if (! $this->installTests()) {


### PR DESCRIPTION
Improves the API stack installation considering Sail projects and ensures consistency between `.env` and `.env.example`.

### Consistency between `.env` and `.env.example`

Changes that were previously applied only to `.env` are now also applied to `.env.example`. This ensures that the `.env.example` file contains all the necessary environment variables, making it easier for team developers to set up the project. (Especially important for Sail projects, see below.)

### Considering API stack

**Remove `VITE_PORT` from `docker-compose.yml` and `VITE_APP_NAME` from environment files**: Since Vite is not used in the API stack, these are not needed.

### Considering Sail projects

**Add `APP_PORT` to environment files**: This is needed because when running `sail up`, the API is only accessible at http://localhost:80 instead of the intended http://localhost:8000. When `APP_PORT` is not set in the `.env` file, the [sail binary defaults it to port 80](https://github.com/laravel/sail/blob/1.x/bin/sail#L142), causing this issue. Modifying the ports in `docker-compose.yml` doesn't resolve this issue (as attempted in #464), because the `sail` binary exports `APP_PORT` before `docker-compose.yml` is applied. Adding `APP_PORT` to `.env` resolves the issue.

---
This PR combines the changes from #463 + #465, since they were interrelated.
