### PR TITLE
[2.x] [ApiStack] Remove `node_modules` and associated lock files

### DIFF
--- a/src/Console/InstallsApiStack.php
+++ b/src/Console/InstallsApiStack.php
@@ -92,5 +92,8 @@ trait InstallsApiStack
         // Remove CSS and JavaScript directories...
         $files->deleteDirectory(resource_path('css'));
         $files->deleteDirectory(resource_path('js'));
+
+        // Remove the "node_modules" directory and associated lock files...
+        static::flushNodeModules();
     }
 }


### PR DESCRIPTION
Since `package.json` is already removed in `removeScaffoldingUnnecessaryForApis()`, we may also remove `node_modules` and associated lock files (`package-lock.json`, `yarn.lock`, etc.)