### PR TITLE
[2.x] Bump Livewire to 3.6.4

### DIFF
--- a/src/Console/InstallsLivewireStack.php
+++ b/src/Console/InstallsLivewireStack.php
@@ -26,7 +26,7 @@ trait InstallsLivewireStack
         });
 
         // Install Livewire...
-        if (! $this->requireComposerPackages(['livewire/livewire:^3.4', 'livewire/volt:^1.7.0'])) {
+        if (! $this->requireComposerPackages(['livewire/livewire:^3.6.4', 'livewire/volt:^1.7.0'])) {
             return 1;
         }
 


### PR DESCRIPTION
Probably best to bump the Livewire version to 3.6.4 to address https://github.com/livewire/livewire/security/advisories/GHSA-29cq-5w36-x7w3