### PR TITLE
[2.x] Bump plugin-vue to ^6.0.0

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -24,7 +24,7 @@ trait InstallsInertiaStacks
             return [
                 '@inertiajs/vue3' => '^2.0.0',
                 '@tailwindcss/forms' => '^0.5.3',
-                '@vitejs/plugin-vue' => '^5.0.0',
+                '@vitejs/plugin-vue' => '^6.0.0',
                 'autoprefixer' => '^10.4.12',
                 'postcss' => '^8.4.31',
                 'tailwindcss' => '^3.2.1',


### PR DESCRIPTION
This change updates https://github.com/vitejs/vite-plugin-vue version to ^6.0.0 . Which fixes the currently failing breeze+inertia installation.

Currently breeze + vue + inertia  fails with the following message - 

```bash
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: undefined@undefined
npm error Found: vite@7.1.2
npm error node_modules/vite
npm error   dev vite@"^7.0.4" from the root project
npm error
npm error Could not resolve dependency:
npm error peer vite@"^5.0.0 || ^6.0.0" from @vitejs/plugin-vue@5.2.4
npm error node_modules/@vitejs/plugin-vue
npm error   dev @vitejs/plugin-vue@"^5.0.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /home/aa/.npm/_logs/2025-08-12T19_54_43_860Z-eresolve-report.txt
npm error A complete log of this run can be found in: /home/aa/.npm/_logs/2025-08-12T19_54_43_860Z-debug-0.log
```

 plugin-vue is set 5.0 , because of which the desired vite 7.1.2 is not being installed

https://github.com/vitejs/vite-plugin-vue/releases - 6.0.1 was released 2 weeks ago, which support 7.1.2

I also noticed  breeze + react installs just fine.

----
Tested locally, 
- modified composer.json to use my fork,
- then installed breeze: `php artisan breeze:install vue` 
- `npm run build ; npm run dev` 

All Good


 
