### PR TITLE
[Feature]: Inertia 3

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -15,14 +15,15 @@ trait InstallsInertiaStacks
     protected function installInertiaVueStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^2.0', 'laravel/sanctum:^4.0', 'tightenco/ziggy:^2.0'])) {
+        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^3.0', 'laravel/sanctum:^4.0', 'tightenco/ziggy:^2.0'])) {
             return 1;
         }
 
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@inertiajs/vue3' => '^2.0.0',
+                '@inertiajs/vite' => '^3.0',
+                '@inertiajs/vue3' => '^3.0',
                 '@tailwindcss/forms' => '^0.5.3',
                 '@vitejs/plugin-vue' => '^6.0.0',
                 'autoprefixer' => '^10.4.12',
@@ -206,11 +207,37 @@ trait InstallsInertiaStacks
 
         if ($this->option('typescript')) {
             copy(__DIR__.'/../../stubs/inertia-vue-ts/resources/js/ssr.ts', resource_path('js/ssr.ts'));
-            $this->replaceInFile("input: 'resources/js/app.ts',", "input: 'resources/js/app.ts',".PHP_EOL."            ssr: 'resources/js/ssr.ts',", base_path('vite.config.js'));
+            $this->replaceInFile(
+                <<<'EOT'
+            input: ['resources/js/app.ts'],
+            refresh: true,
+            EOT,
+                <<<'EOT'
+            input: ['resources/js/app.ts'],
+            ssr: 'resources/js/ssr.ts',
+            refresh: true,
+            EOT,
+                base_path('vite.config.js')
+            );
         } else {
             copy(__DIR__.'/../../stubs/inertia-vue/resources/js/ssr.js', resource_path('js/ssr.js'));
-            $this->replaceInFile("input: 'resources/js/app.js',", "input: 'resources/js/app.js',".PHP_EOL."            ssr: 'resources/js/ssr.js',", base_path('vite.config.js'));
+            $this->replaceInFile(
+                <<<'EOT'
+            input: ['resources/js/app.js'],
+            refresh: true,
+            EOT,
+                <<<'EOT'
+            input: ['resources/js/app.js'],
+            ssr: 'resources/js/ssr.js',
+            refresh: true,
+            EOT,
+                base_path('vite.config.js')
+            );
         }
+
+        $this->replaceInertiaVitePluginSsrConfig(
+            $this->option('typescript') ? 'resources/js/ssr.ts' : 'resources/js/ssr.js'
+        );
 
         $this->configureZiggyForSsr();
 
@@ -226,7 +253,7 @@ trait InstallsInertiaStacks
     protected function installInertiaReactStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^2.0', 'laravel/sanctum:^4.0', 'tightenco/ziggy:^2.0'])) {
+        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^3.0', 'laravel/sanctum:^4.0', 'tightenco/ziggy:^2.0'])) {
             return 1;
         }
 
@@ -234,14 +261,15 @@ trait InstallsInertiaStacks
         $this->updateNodePackages(function ($packages) {
             return [
                 '@headlessui/react' => '^2.0.0',
-                '@inertiajs/react' => '^2.0.0',
+                '@inertiajs/vite' => '^3.0',
+                '@inertiajs/react' => '^3.0',
                 '@tailwindcss/forms' => '^0.5.3',
                 '@vitejs/plugin-react' => '^4.2.0',
                 'autoprefixer' => '^10.4.12',
                 'postcss' => '^8.4.31',
                 'tailwindcss' => '^3.2.1',
-                'react' => '^18.2.0',
-                'react-dom' => '^18.2.0',
+                'react' => '^19.0',
+                'react-dom' => '^19.0',
             ] + $packages;
         });
 
@@ -249,8 +277,8 @@ trait InstallsInertiaStacks
             $this->updateNodePackages(function ($packages) {
                 return [
                     '@types/node' => '^18.13.0',
-                    '@types/react' => '^18.0.28',
-                    '@types/react-dom' => '^18.0.10',
+                    '@types/react' => '^19.0',
+                    '@types/react-dom' => '^19.0',
                     'typescript' => '^5.0.2',
                 ] + $packages;
             });
@@ -422,13 +450,37 @@ trait InstallsInertiaStacks
     {
         if ($this->option('typescript')) {
             copy(__DIR__.'/../../stubs/inertia-react-ts/resources/js/ssr.tsx', resource_path('js/ssr.tsx'));
-            $this->replaceInFile("input: 'resources/js/app.tsx',", "input: 'resources/js/app.tsx',".PHP_EOL."            ssr: 'resources/js/ssr.tsx',", base_path('vite.config.js'));
-            $this->configureReactHydrateRootForSsr(resource_path('js/app.tsx'));
+            $this->replaceInFile(
+                <<<'EOT'
+            input: ['resources/js/app.tsx'],
+            refresh: true,
+            EOT,
+                <<<'EOT'
+            input: ['resources/js/app.tsx'],
+            ssr: 'resources/js/ssr.tsx',
+            refresh: true,
+            EOT,
+                base_path('vite.config.js')
+            );
         } else {
             copy(__DIR__.'/../../stubs/inertia-react/resources/js/ssr.jsx', resource_path('js/ssr.jsx'));
-            $this->replaceInFile("input: 'resources/js/app.jsx',", "input: 'resources/js/app.jsx',".PHP_EOL."            ssr: 'resources/js/ssr.jsx',", base_path('vite.config.js'));
-            $this->configureReactHydrateRootForSsr(resource_path('js/app.jsx'));
+            $this->replaceInFile(
+                <<<'EOT'
+            input: ['resources/js/app.jsx'],
+            refresh: true,
+            EOT,
+                <<<'EOT'
+            input: ['resources/js/app.jsx'],
+            ssr: 'resources/js/ssr.jsx',
+            refresh: true,
+            EOT,
+                base_path('vite.config.js')
+            );
         }
+
+        $this->replaceInertiaVitePluginSsrConfig(
+            $this->option('typescript') ? 'resources/js/ssr.tsx' : 'resources/js/ssr.jsx'
+        );
 
         $this->configureZiggyForSsr();
 
@@ -437,38 +489,27 @@ trait InstallsInertiaStacks
     }
 
     /**
-     * Configure the application JavaScript file to utilize hydrateRoot for SSR.
+     * Point the Inertia Vite plugin at the SSR bundle (see https://inertiajs.com/docs/v3/advanced/server-side-rendering).
      *
-     * @param  string  $path
      * @return void
      */
-    protected function configureReactHydrateRootForSsr($path)
+    protected function replaceInertiaVitePluginSsrConfig(string $ssrEntry)
     {
         $this->replaceInFile(
             <<<'EOT'
-            import { createRoot } from 'react-dom/client';
-            EOT,
-            <<<'EOT'
-            import { createRoot, hydrateRoot } from 'react-dom/client';
-            EOT,
-            $path
-        );
-
-        $this->replaceInFile(
-            <<<'EOT'
-                    const root = createRoot(el);
-
-                    root.render(<App {...props} />);
-            EOT,
-            <<<'EOT'
-                    if (import.meta.env.SSR) {
-                        hydrateRoot(el, <App {...props} />);
-                        return;
-                    }
-
-                    createRoot(el).render(<App {...props} />);
-            EOT,
-            $path
+        inertia(),
+        EOT,
+            sprintf(
+                <<<'EOT'
+        inertia({
+            ssr: {
+                entry: '%s',
+            },
+        }),
+        EOT,
+                $ssrEntry
+            ),
+            base_path('vite.config.js')
         );
     }
 

--- a/stubs/inertia-react-ts/resources/js/app.tsx
+++ b/stubs/inertia-react-ts/resources/js/app.tsx
@@ -2,22 +2,13 @@ import '../css/app.css';
 import './bootstrap';
 
 import { createInertiaApp } from '@inertiajs/react';
-import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createRoot } from 'react-dom/client';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
-    resolve: (name) =>
-        resolvePageComponent(
-            `./Pages/${name}.tsx`,
-            import.meta.glob('./Pages/**/*.tsx'),
-        ),
-    setup({ el, App, props }) {
-        const root = createRoot(el);
-
-        root.render(<App {...props} />);
+    withApp(app) {
+        return app;
     },
     progress: {
         color: '#4B5563',

--- a/stubs/inertia-react/resources/js/app.jsx
+++ b/stubs/inertia-react/resources/js/app.jsx
@@ -2,22 +2,13 @@ import '../css/app.css';
 import './bootstrap';
 
 import { createInertiaApp } from '@inertiajs/react';
-import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createRoot } from 'react-dom/client';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
-    resolve: (name) =>
-        resolvePageComponent(
-            `./Pages/${name}.jsx`,
-            import.meta.glob('./Pages/**/*.jsx'),
-        ),
-    setup({ el, App, props }) {
-        const root = createRoot(el);
-
-        root.render(<App {...props} />);
+    withApp(app) {
+        return app;
     },
     progress: {
         color: '#4B5563',

--- a/stubs/inertia-react/resources/views/app.blade.php
+++ b/stubs/inertia-react/resources/views/app.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+        <title data-inertia>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -13,10 +13,10 @@
         <!-- Scripts -->
         @routes
         @viteReactRefresh
-        @vite(['resources/js/app.jsx', "resources/js/Pages/{$page['component']}.jsx"])
-        @inertiaHead
+        @vite(['resources/js/app.jsx'])
+        <x-inertia::head />
     </head>
     <body class="font-sans antialiased">
-        @inertia
+        <x-inertia::app />
     </body>
 </html>

--- a/stubs/inertia-react/vite.config.js
+++ b/stubs/inertia-react/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import react from '@vitejs/plugin-react';
+import inertia from '@inertiajs/vite';
 
 export default defineConfig({
     plugins: [
@@ -9,5 +10,6 @@ export default defineConfig({
             refresh: true,
         }),
         react(),
+        inertia(),
     ],
 });

--- a/stubs/inertia-vue-ts/resources/js/app.ts
+++ b/stubs/inertia-vue-ts/resources/js/app.ts
@@ -2,24 +2,14 @@ import '../css/app.css';
 import './bootstrap';
 
 import { createInertiaApp } from '@inertiajs/vue3';
-import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createApp, DefineComponent, h } from 'vue';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
-    resolve: (name) =>
-        resolvePageComponent(
-            `./Pages/${name}.vue`,
-            import.meta.glob<DefineComponent>('./Pages/**/*.vue'),
-        ),
-    setup({ el, App, props, plugin }) {
-        createApp({ render: () => h(App, props) })
-            .use(plugin)
-            .use(ZiggyVue)
-            .mount(el);
+    withApp(app) {
+        app.use(ZiggyVue);
     },
     progress: {
         color: '#4B5563',

--- a/stubs/inertia-vue/resources/js/app.js
+++ b/stubs/inertia-vue/resources/js/app.js
@@ -2,24 +2,14 @@ import '../css/app.css';
 import './bootstrap';
 
 import { createInertiaApp } from '@inertiajs/vue3';
-import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createApp, h } from 'vue';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
-    resolve: (name) =>
-        resolvePageComponent(
-            `./Pages/${name}.vue`,
-            import.meta.glob('./Pages/**/*.vue'),
-        ),
-    setup({ el, App, props, plugin }) {
-        return createApp({ render: () => h(App, props) })
-            .use(plugin)
-            .use(ZiggyVue)
-            .mount(el);
+    withApp(app) {
+        app.use(ZiggyVue);
     },
     progress: {
         color: '#4B5563',

--- a/stubs/inertia-vue/resources/views/app.blade.php
+++ b/stubs/inertia-vue/resources/views/app.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+        <title data-inertia>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -12,10 +12,10 @@
 
         <!-- Scripts -->
         @routes
-        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
-        @inertiaHead
+        @vite(['resources/js/app.js'])
+        <x-inertia::head />
     </head>
     <body class="font-sans antialiased">
-        @inertia
+        <x-inertia::app />
     </body>
 </html>

--- a/stubs/inertia-vue/vite.config.js
+++ b/stubs/inertia-vue/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
+import inertia from '@inertiajs/vite';
 
 export default defineConfig({
     plugins: [
@@ -16,5 +17,6 @@ export default defineConfig({
                 },
             },
         }),
+        inertia(),
     ],
 });


### PR DESCRIPTION
Update Breeze’s Inertia stacks (Vue and React) to Inertia v3 and `@inertiajs/vite`.

- PHP/JS dependencies aligned with v3; React 19 where required
- Vite uses the i`nertia()` plugin; client entries match the docs
- Optional SSR via _ssr.*_, Ziggy, and an explicit entry in the Inertia plugin
- Root Blade template uses Inertia v3 components and data-inertia on `<title>`