### PR TITLE
Fix Blade scaffold build failure from missing bootstrap module

### DIFF
--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -25,6 +25,13 @@ trait InstallsBladeStack
             ] + $packages;
         });
 
+        // NPM Dependencies...
+        $this->updateNodePackages(function ($packages) {
+            return [
+                'axios' => '^1.7.4',
+            ] + $packages;
+        }, false);
+
         // Controllers...
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Controllers'));
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/default/app/Http/Controllers', app_path('Http/Controllers'));
@@ -68,6 +75,7 @@ trait InstallsBladeStack
         copy(__DIR__.'/../../stubs/default/postcss.config.js', base_path('postcss.config.js'));
         copy(__DIR__.'/../../stubs/default/vite.config.js', base_path('vite.config.js'));
         copy(__DIR__.'/../../stubs/default/resources/css/app.css', resource_path('css/app.css'));
+        copy(__DIR__.'/../../stubs/default/resources/js/bootstrap.js', resource_path('js/bootstrap.js'));
         copy(__DIR__.'/../../stubs/default/resources/js/app.js', resource_path('js/app.js'));
 
         $this->components->info('Installing and building Node dependencies.');

--- a/stubs/default/resources/js/bootstrap.js
+++ b/stubs/default/resources/js/bootstrap.js
@@ -1,0 +1,4 @@
+import axios from 'axios';
+window.axios = axios;
+
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';


### PR DESCRIPTION
## Summary
This fixes a Blade stack scaffolding regression where the generated frontend entry imports ./bootstrap but the file is not created, causing Vite to fail during the post-install build.

## Problem
After running Breeze Blade install, the generated app can fail on npm run build with unresolved import for ./bootstrap from resources/js/app.js.

## Root cause
- Blade scaffold writes resources/js/app.js with an import './bootstrap'
- Blade stubs did not provide/copy resources/js/bootstrap.js
- Blade install path did not ensure axios dependency for the bootstrap file

## Changes
- Added Blade stub resources/js/bootstrap.js
- Updated Blade installer to copy that stub into the target app
- Ensured axios is added as a dependency in the Blade install path

## Impact
Fixes first-run Blade scaffold build reliability for Blade installations.