### PR TITLE
Fix: Remove bootstrap.js import for Laravel 13+

### DIFF
--- a/src/Console/InstallsBladeStack.php
+++ b/src/Console/InstallsBladeStack.php
@@ -70,6 +70,10 @@ trait InstallsBladeStack
         copy(__DIR__.'/../../stubs/default/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/default/resources/js/app.js', resource_path('js/app.js'));
 
+        if (version_compare(\Illuminate\Foundation\Application::VERSION, '13.0.0', '>=')) {
+            $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.js'));
+        }
+
         $this->components->info('Installing and building Node dependencies.');
 
         if (file_exists(base_path('pnpm-lock.yaml'))) {


### PR DESCRIPTION
Laravel 13 skeleton does not have the `resources/js/bootstrap.js` file. However, the Breeze installer still adds `import './bootstrap';` line to the app.js file, which causes Vite to fail with a `Failed to resolve import` error.

This PR adds a version check during the installation process. If the application is running Laravel 13 or higher, the `import './bootstrap';` line is removed from the generated app.js file.

This is one of my first pull requests, I apologize if I did something wrong.