### PR TITLE
Pin pull requests and issues workflows to least-privilege reusable workflows

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   help-wanted:
-    uses: laravel/.github/.github/workflows/issues.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/issues.yml@ae831fb2746b4ad21f6751fde03da7d146822d61 # main

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   uneditable:
-    uses: laravel/.github/.github/workflows/pull-requests.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/pull-requests.yml@ae831fb2746b4ad21f6751fde03da7d146822d61 # main


### PR DESCRIPTION
The `pull requests` and `issues` workflows pin reusable workflows in `laravel/.github` at a revision that declared permission scopes none of their steps use (`contents: read`, and on issues also `pull-requests: write`). Because a reusable workflow may not request more permission than its caller grants, those extra declarations made the workflows fail at startup (`requesting 'contents: read', but is only allowed 'contents: none'`).

laravel/.github#36 trimmed those reusable workflows to least-privilege. This bumps the pins to that revision; the existing `pull-requests: write` / `issues: write` caller permissions are already correct and left unchanged.