### PR TITLE
fix: Remove bootstrap.js import for Laravel 13+ for inertia stacks

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -3,6 +3,7 @@
 namespace Laravel\Breeze\Console;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
 use Symfony\Component\Finder\Finder;
 
 trait InstallsInertiaStacks
@@ -163,12 +164,20 @@ trait InstallsInertiaStacks
                 rename(resource_path('js/bootstrap.js'), resource_path('js/bootstrap.ts'));
             }
 
+            if (version_compare(Application::VERSION, '13.0.0', '>=')) {
+                $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.ts'));
+            }
+
             $this->replaceInFile('"vite build', '"vue-tsc && vite build', base_path('package.json'));
             $this->replaceInFile('.js', '.ts', base_path('vite.config.js'));
             $this->replaceInFile('.js', '.ts', resource_path('views/app.blade.php'));
         } else {
             copy(__DIR__.'/../../stubs/inertia-common/jsconfig.json', base_path('jsconfig.json'));
             copy(__DIR__.'/../../stubs/inertia-vue/resources/js/app.js', resource_path('js/app.js'));
+
+            if (version_compare(Application::VERSION, '13.0.0', '>=')) {
+                $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.js'));
+            }
         }
 
         if ($this->option('ssr')) {
@@ -376,6 +385,10 @@ trait InstallsInertiaStacks
                 rename(resource_path('js/bootstrap.js'), resource_path('js/bootstrap.ts'));
             }
 
+            if (version_compare(Application::VERSION, '13.0.0', '>=')) {
+                $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.tsx'));
+            }
+
             $this->replaceInFile('"vite build', '"tsc && vite build', base_path('package.json'));
             $this->replaceInFile('.jsx', '.tsx', base_path('vite.config.js'));
             $this->replaceInFile('.jsx', '.tsx', resource_path('views/app.blade.php'));
@@ -383,6 +396,10 @@ trait InstallsInertiaStacks
         } else {
             copy(__DIR__.'/../../stubs/inertia-common/jsconfig.json', base_path('jsconfig.json'));
             copy(__DIR__.'/../../stubs/inertia-react/resources/js/app.jsx', resource_path('js/app.jsx'));
+
+            if (version_compare(Application::VERSION, '13.0.0', '>=')) {
+                $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.jsx'));
+            }
 
             $this->replaceInFile('.vue', '.jsx', base_path('tailwind.config.js'));
         }


### PR DESCRIPTION
In Laravel 13 projects, the following error is displayed when running npm build during breeze project initialization:

```bash
✗ Build failed in 105ms
error during build:
Build failed with 1 error:

[UNRESOLVED_IMPORT] Could not resolve './bootstrap' in resources/js/app.ts
   ╭─[ resources/js/app.ts:2:8 ]
   │
 2 │ import "./bootstrap";
   │        ──────┬──────
   │              ╰──────── Module not found.
───╯
```

I have noticed that a similar issue for the blade stack has been fixed in #486 . I have used the same approach for the inertia stack with consideration to the typescript option.

### HOW I TESTED THIS FIX

```
composer create-project laravel/laravel:^13.0 vue13-ts
cd vue13-ts

composer require laravel/breeze:@dev --no-interaction --no-update
composer config repositories.breeze '{"type":"path","url":"/Users/{user}/Code/LaravelProjects/breeze"}' --file composer.json
composer update laravel/breeze --prefer-dist --no-interaction --no-progress -W

php artisan breeze:install vue --typescript
```